### PR TITLE
poprawki na atlasie

### DIFF
--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -1005,6 +1005,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "du" = (
@@ -1570,6 +1573,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/tile/ship/half/yellow,
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "fq" = (
@@ -1770,6 +1774,7 @@
 /obj/effect/turf_decal/tile/ship/half/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/ship/yellow,
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "fS" = (
@@ -1923,6 +1928,9 @@
 /area/hallway/nsv/deck2/primary)
 "gi" = (
 /obj/machinery/vending/security,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "gk" = (
@@ -3833,7 +3841,9 @@
 /area/hallway/nsv/deck2/primary)
 "lK" = (
 /obj/structure/closet/radiation,
-/obj/effect/turf_decal/tile/ship/half/yellow,
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "lL" = (
@@ -5688,6 +5698,7 @@
 /obj/structure/closet/radiation,
 /obj/item/geiger_counter,
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/tile/ship/half/yellow,
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "rz" = (
@@ -6449,6 +6460,9 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "tN" = (
@@ -6761,6 +6775,7 @@
 /obj/item/clothing/suit/radiation,
 /obj/item/clothing/head/radiation,
 /obj/machinery/light,
+/obj/effect/turf_decal/tile/ship/half/yellow,
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "uA" = (
@@ -7474,7 +7489,6 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "wW" = (
-/obj/effect/turf_decal/tile/ship/half/yellow,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
@@ -8599,7 +8613,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "Ba" = (
-/obj/effect/turf_decal/tile/ship/half/yellow,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -8669,7 +8682,9 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
-/obj/effect/turf_decal/tile/ship/half/yellow,
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "Br" = (
@@ -8974,6 +8989,13 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/carpet/red,
 /area/nsv/weapons)
+"Co" = (
+/obj/structure/chair/stool,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/carpet/red,
+/area/nsv/weapons)
 "Cp" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
@@ -9120,7 +9142,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/ship/half/yellow,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
@@ -10361,6 +10382,9 @@
 	},
 /obj/effect/spawner/lootdrop/armory_contraband,
 /obj/item/gun/ballistic/shotgun/riot,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory)
 "HD" = (
@@ -14640,7 +14664,6 @@
 /turf/open/floor/plasteel/techmaint,
 /area/nsv/hanger/mining)
 "Vi" = (
-/obj/effect/turf_decal/tile/ship/half/yellow,
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "Vj" = (
@@ -15186,6 +15209,12 @@
 	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
+"WZ" = (
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/engine_room)
 "Xc" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -40835,8 +40864,8 @@ gS
 gS
 gS
 cH
-kD
-kD
+MO
+MO
 ue
 FQ
 MO
@@ -41091,7 +41120,7 @@ gN
 gS
 gS
 gS
-kD
+MO
 MO
 MO
 MO
@@ -41347,7 +41376,7 @@ gS
 gS
 gS
 gS
-kD
+MO
 MO
 MO
 Dh
@@ -41604,7 +41633,7 @@ gS
 gS
 gS
 gS
-kD
+MO
 MO
 cZ
 mX
@@ -41861,7 +41890,7 @@ hG
 hG
 gS
 gS
-kD
+MO
 MO
 eB
 eN
@@ -43662,9 +43691,9 @@ Jh
 kH
 kH
 yI
-YQ
+MO
 fP
-Vi
+WZ
 oz
 oz
 Zh
@@ -43919,7 +43948,7 @@ aI
 dj
 rR
 qK
-qI
+oF
 oF
 lK
 oz
@@ -55482,7 +55511,7 @@ lz
 eY
 kd
 yA
-RQ
+Co
 Cn
 eY
 lf

--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -40,6 +40,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"ae" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port/fore)
 "af" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -62,6 +68,9 @@
 "ah" = (
 /obj/structure/chair/office,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "aj" = (
@@ -234,6 +243,9 @@
 /obj/structure/window/reinforced,
 /obj/item/paper/guides/jobs/hydroponics,
 /obj/item/reagent_containers/glass/bucket,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/security/prison)
 "aH" = (
@@ -271,6 +283,21 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/south,
+/turf/open/floor/durasteel/alt,
+/area/hallway/nsv/deck2/primary)
+"aN" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
 "aP" = (
@@ -316,6 +343,9 @@
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
@@ -472,17 +502,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "bz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner{
+	dir = 8;
+	pixel_y = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/science)
+/turf/open/space/basic,
+/area/space/nearstation)
 "bA" = (
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Brig Maintenance";
@@ -637,6 +663,9 @@
 /obj/machinery/light_switch/west,
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
 	},
 /turf/open/floor/durasteel/techfloor,
 /area/maintenance/nsv/deck2/starboard)
@@ -860,6 +889,12 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/carpet/orange,
 /area/engine/engine_room)
+"da" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/window/reinforced,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/engine,
+/area/science)
 "dd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1142,14 +1177,8 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "dU" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold4w/general/hidden,
+/turf/open/floor/circuit/telecomms,
 /area/science)
 "dW" = (
 /obj/structure/cable{
@@ -1231,20 +1260,12 @@
 /area/hallway/secondary/exit/departure_lounge)
 "en" = (
 /obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
 	icon_state = "2-8";
 	tag = ""
 	},
-/obj/structure/disposalpipe/trunk{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/light_switch/east,
 /turf/open/floor/monotile/dark,
 /area/science)
 "eo" = (
@@ -1495,11 +1516,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only/directional/east,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "ff" = (
@@ -1548,6 +1567,9 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "fq" = (
@@ -1591,6 +1613,10 @@
 "fu" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 6
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science)
@@ -1680,6 +1706,9 @@
 "fG" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/computer/ship/viewscreen,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/security/prison)
 "fH" = (
@@ -1809,7 +1838,7 @@
 /obj/item/storage/box/monkeycubes,
 /obj/machinery/firealarm/directional/east,
 /obj/item/storage/bag/bio,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/plasteel/techmaint,
 /area/science)
 "ga" = (
 /obj/structure/railing{
@@ -1870,6 +1899,9 @@
 /area/nsv/hanger/notkmcstupidhanger)
 "gf" = (
 /obj/structure/tank_dispenser,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/carpet/orange,
 /area/engine/engine_room)
 "gg" = (
@@ -2120,6 +2152,9 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/gauss/battery/deck2/port)
 "gX" = (
@@ -2186,6 +2221,17 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/nsv/deck2/starboard)
+"hh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Kill Chamber";
+	network = list("ss13","rd","xeno")
+	},
+/turf/open/floor/circuit/telecomms,
+/area/science)
 "hi" = (
 /obj/structure/closet/secure_closet/munitions_technician,
 /turf/open/floor/carpet/red,
@@ -2466,16 +2512,21 @@
 	},
 /obj/structure/railing,
 /obj/structure/railing,
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/space/nearstation)
 "hV" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/computer/camera_advanced/xenobio{
+	dir = 8
 	},
-/turf/open/floor/monotile/steel,
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/turf/open/floor/plasteel/techmaint,
 /area/science)
 "hX" = (
 /obj/effect/turf_decal/ship/delivery/yellow,
@@ -2680,16 +2731,14 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "iQ" = (
-/obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/window/reinforced,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/circuit/telecomms,
 /area/science)
 "iR" = (
@@ -3165,6 +3214,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit/departure_lounge)
 "kk" = (
@@ -3178,6 +3230,10 @@
 /area/maintenance/nsv/deck2/port/fore)
 "km" = (
 /obj/machinery/rnd/server,
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
 /turf/open/floor/circuit/telecomms,
 /area/science)
 "kn" = (
@@ -3268,10 +3324,12 @@
 /area/science)
 "kv" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/advanced_airlock_controller/directional/east{
 	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit/departure_lounge)
@@ -3377,17 +3435,12 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/nsv/deck2/port)
 "kI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/lattice/catwalk/over/ship,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/science)
+/turf/open/floor/monotile/steel,
+/area/nsv/weapons)
 "kJ" = (
 /obj/machinery/door/airlock/ship/engineering/glass{
 	name = "ATC"
@@ -3479,7 +3532,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/monotile/steel,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
 /area/science)
 "kW" = (
 /obj/structure/shuttle/engine/large{
@@ -3594,21 +3650,15 @@
 	},
 /area/maintenance/department/engine/atmos)
 "ln" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/science)
@@ -3836,7 +3886,8 @@
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/monotile/dark,
+/obj/machinery/holopad,
+/turf/open/floor/monotile/steel,
 /area/science)
 "lW" = (
 /obj/structure/cable{
@@ -4182,6 +4233,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/science)
 "nn" = (
@@ -4500,13 +4554,16 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "ok" = (
-/obj/item/extinguisher{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/extinguisher,
 /obj/machinery/monkey_recycler,
-/turf/open/floor/monotile/steel,
+/obj/structure/extinguisher_cabinet/north{
+	pixel_y = 0;
+	pixel_x = 39
+	},
+/obj/structure/extinguisher_cabinet/north{
+	pixel_x = 25;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/techmaint,
 /area/science)
 "om" = (
 /obj/machinery/vending/engivend,
@@ -4688,10 +4745,12 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/engine/engine_room)
 "oM" = (
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/trunk,
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
 	},
 /turf/open/floor/engine,
 /area/science)
@@ -5128,7 +5187,8 @@
 /area/nsv/weapons)
 "pQ" = (
 /obj/structure/marker_beacon,
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/space/nearstation)
 "pS" = (
 /obj/structure/closet/firecloset,
@@ -5183,14 +5243,18 @@
 	brightness = 3;
 	dir = 1
 	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
 /turf/open/floor/circuit/telecomms,
 /area/science)
 "pX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/machinery/camera{
+	c_tag = "Xenobiology Lab - Pen #2";
+	network = list("ss13","rd","xeno")
 	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/science)
 "pY" = (
 /obj/structure/cable/yellow{
@@ -5273,16 +5337,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/turf/open/floor/monotile/dark,
+/turf/open/floor/monotile/steel,
 /area/science)
 "qi" = (
 /obj/machinery/door/airlock/ship/maintenance,
@@ -5348,6 +5409,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
@@ -5705,6 +5769,9 @@
 	dir = 8
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "rK" = (
@@ -5731,6 +5798,9 @@
 "rN" = (
 /obj/item/stock_parts/micro_laser,
 /obj/structure/frame/machine,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "rO" = (
@@ -5881,16 +5951,11 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "si" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet/north,
-/turf/open/floor/monotile/dark,
-/area/science)
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "sj" = (
 /obj/machinery/door/airlock/ship/maintenance,
 /obj/machinery/door/firedoor/border_only,
@@ -6113,7 +6178,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/monotile/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
 /area/science)
 "tg" = (
 /obj/machinery/atmospherics/components/binary/pump/layer4{
@@ -6289,6 +6357,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "tz" = (
 /obj/machinery/seed_extractor,
+/obj/machinery/status_display/evac/west,
 /turf/open/floor/plasteel/techmaint,
 /area/security/prison)
 "tA" = (
@@ -6308,6 +6377,15 @@
 	},
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/quartermaster/qm)
+"tC" = (
+/obj/effect/turf_decal/tile/ship/half/green{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "tD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -6322,6 +6400,20 @@
 /obj/machinery/light,
 /turf/open/space/basic,
 /area/nsv/hanger/notkmcstupidhanger)
+"tF" = (
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/durasteel/alt,
+/area/hallway/nsv/deck2/primary)
 "tG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6343,6 +6435,9 @@
 /area/maintenance/nsv/deck2/starboard)
 "tL" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/abandoned_gambling_den{
 	name = "Abandoned Bar"
@@ -6745,13 +6840,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/machinery/processor/slime,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light,
 /turf/open/floor/monotile/dark,
 /area/science)
 "uM" = (
@@ -6764,7 +6857,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/space/nearstation)
 "uP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -6795,6 +6889,9 @@
 /obj/item/mop,
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 10
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/open/floor/durasteel/lino,
 /area/janitor)
@@ -6871,9 +6968,6 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "vl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -6921,6 +7015,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/hallway/nsv/deck2/primary)
+"vt" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "vu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -6990,15 +7093,13 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "vG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/window/brigdoor{
+	name = "Creature Pen";
+	req_access_txt = "47"
 	},
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/engine,
 /area/science)
 "vH" = (
 /obj/machinery/computer/atmos_control/tank/mix_tank{
@@ -7225,7 +7326,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/railing,
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/space/nearstation)
 "wA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -7322,6 +7424,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/carpet/orange,
 /area/engine/engine_room)
 "wR" = (
@@ -7352,11 +7457,10 @@
 /turf/open/floor/plasteel/techmaint,
 /area/nsv/weapons)
 "wU" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/landmark/start/depsec/science,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/landmark/start/depsec/science,
 /turf/open/floor/monotile/dark,
 /area/science)
 "wV" = (
@@ -7699,6 +7803,9 @@
 /obj/item/stack/sheet/mineral/wood/five,
 /obj/item/encryptionkey/pilot,
 /obj/machinery/newscaster/directional/north,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/monotile/steel,
 /area/quartermaster/miningoffice)
 "yk" = (
@@ -7924,7 +8031,8 @@
 	icon_state = "1-8"
 	},
 /obj/structure/railing,
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/space/nearstation)
 "yW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -8129,7 +8237,10 @@
 	},
 /obj/machinery/reagentgrinder,
 /obj/item/storage/bag/bio,
-/turf/open/floor/monotile/steel,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/techmaint,
 /area/science)
 "zD" = (
 /turf/open/floor/plating{
@@ -8145,6 +8256,9 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
 	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
@@ -8476,7 +8590,8 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/space/nearstation)
 "Ba" = (
 /obj/effect/turf_decal/tile/ship/half/yellow,
@@ -8498,6 +8613,9 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "Bd" = (
@@ -8506,9 +8624,6 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "Be" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
@@ -8516,7 +8631,7 @@
 	dir = 4
 	},
 /obj/machinery/nanite_program_hub,
-/turf/open/floor/monotile/dark,
+/turf/open/floor/plasteel/techmaint,
 /area/science)
 "Bh" = (
 /obj/effect/turf_decal/ship/techfloor{
@@ -8539,6 +8654,9 @@
 /turf/open/floor/plasteel/grid/steel,
 /area/hallway/secondary/exit/departure_lounge)
 "Bj" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/science)
 "Bp" = (
@@ -8628,14 +8746,18 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "BH" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/monotile/dark,
-/area/science)
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/durasteel/alt,
+/area/hallway/nsv/deck2/primary)
 "BI" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -8723,6 +8845,16 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
+"BS" = (
+/obj/machinery/rnd/server,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1;
+	external_pressure_bound = 140;
+	name = "server vent";
+	pressure_checks = 0
+	},
+/turf/open/floor/circuit/telecomms,
+/area/science)
 "BU" = (
 /turf/closed/wall/r_wall{
 	layer = 2.91
@@ -8815,6 +8947,9 @@
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/camera/autoname{
 	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
@@ -9079,7 +9214,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/hallway/nsv/deck2/primary)
 "Dq" = (
 /obj/machinery/power/terminal{
@@ -9093,7 +9228,8 @@
 "Ds" = (
 /obj/structure/closet/crate,
 /obj/item/stack/ore/iron,
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/space/nearstation)
 "Dt" = (
 /obj/machinery/firealarm{
@@ -9160,11 +9296,20 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/space/nearstation)
 "DH" = (
 /turf/closed/wall/r_wall,
 /area/quartermaster/miningoffice)
+"DL" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner{
+	dir = 1;
+	pixel_y = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "DM" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -9289,8 +9434,9 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "Ei" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/obj/structure/ore_box,
+/turf/open/space/basic,
 /area/space/nearstation)
 "Ek" = (
 /obj/structure/cable{
@@ -9379,6 +9525,9 @@
 /area/maintenance/nsv/deck2/port/fore)
 "EF" = (
 /obj/machinery/nanite_chamber,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/monotile/dark,
 /area/science)
 "EG" = (
@@ -9425,7 +9574,8 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/space/nearstation)
 "ER" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
@@ -9569,6 +9719,16 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/monotile/steel,
 /area/engine/engine_room)
+"Fu" = (
+/obj/effect/turf_decal/tile/ship/half/green,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "Fv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/monotile/steel,
@@ -9739,6 +9899,9 @@
 	pixel_x = -5;
 	pixel_y = 6
 	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "FY" = (
@@ -9749,18 +9912,13 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "Gd" = (
-/obj/machinery/computer/camera_advanced/xenobio{
-	dir = 8
-	},
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/techmaint,
 /area/science)
 "Gf" = (
 /obj/structure/cable{
@@ -9835,6 +9993,15 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/starboard)
+"Gq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "Gs" = (
@@ -9999,18 +10166,17 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engine_room)
+"GW" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "GX" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/dark,
 /area/science)
 "GZ" = (
 /obj/effect/turf_decal/tile/ship/red{
@@ -10097,7 +10263,8 @@
 /area/maintenance/nsv/deck2/starboard)
 "Hl" = (
 /obj/structure/closet/crate,
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/space/nearstation)
 "Ho" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -10283,6 +10450,9 @@
 	desc = "Nothing like a potted plant to bring nature onto the ship. This one appears to have died.";
 	icon_state = "plant-25"
 	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
 	},
@@ -10427,6 +10597,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"Iy" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/techmaint,
+/area/science)
 "Iz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10490,6 +10670,16 @@
 /area/crew_quarters/abandoned_gambling_den{
 	name = "Abandoned Bar"
 	})
+"IR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/yellow,
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "IS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -10543,7 +10733,10 @@
 	dir = 8
 	},
 /obj/structure/sign/nanotrasen{
-	pixel_y = 26
+	pixel_y = 32
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -10576,23 +10769,21 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "Ji" = (
-/obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 5
-	},
-/turf/open/floor/circuit/telecomms,
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/engine,
 /area/science)
 "Jj" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/space/nearstation)
 "Jk" = (
 /turf/open/floor/monotile/steel,
@@ -11102,14 +11293,11 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "KK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/dark,
 /area/science)
 "KM" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -11248,7 +11436,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/chem_heater,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/science)
 "Ld" = (
 /obj/structure/cable{
@@ -11320,15 +11508,16 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit/departure_lounge)
 "Lq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/ship/orange,
+/obj/effect/turf_decal/tile/ship/orange{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
-/turf/open/floor/plating,
-/area/science)
+/turf/open/floor/durasteel/alt,
+/area/hallway/nsv/deck2/primary)
 "Lr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11362,6 +11551,7 @@
 /obj/machinery/light/small/broken{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/north,
 /turf/open/floor/durasteel/techfloor,
 /area/maintenance/nsv/deck2/port)
 "Lw" = (
@@ -11427,18 +11617,24 @@
 	dir = 4
 	},
 /obj/machinery/suit_storage_unit/atmos,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
 /area/engine/atmos)
 "LF" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/engine,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/science)
 "LG" = (
 /obj/machinery/camera{
-	c_tag = "Xenobiology Lab - Kill Chamber";
+	c_tag = "Xenobiology Lab - Pen #1";
 	network = list("ss13","rd","xeno")
 	},
-/turf/open/floor/circuit/telecomms,
+/turf/open/floor/engine,
 /area/science)
 "LH" = (
 /obj/structure/disposalpipe/segment{
@@ -11556,7 +11752,11 @@
 /turf/open/floor/mech_bay_recharge_floor,
 /area/science)
 "LZ" = (
-/turf/open/floor/circuit/telecomms,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/turf/open/floor/engine,
 /area/science)
 "Ma" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -11801,23 +12001,11 @@
 /area/nsv/weapons)
 "MD" = (
 /obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/ship/station{
-	name = "Xenobiology Euthanization Chamber";
-	req_one_access_txt = "55"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/monotile/dark,
-/area/science)
+/obj/machinery/holopad,
+/turf/open/floor/durasteel/techfloor_grid,
+/area/security/prison)
 "MF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -11876,9 +12064,6 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "MW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/meter/atmos/distro_loop{
 	target_layer = 2;
@@ -11934,20 +12119,12 @@
 /area/nsv/weapons)
 "Nf" = (
 /obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Creature Pen";
-	req_access_txt = "47"
-	},
-/obj/machinery/door/window/brigdoor{
 	name = "Creature Pen";
 	req_access_txt = "47"
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
 /obj/effect/landmark/zebra_interlock_point,
-/turf/open/floor/monotile/dark,
+/turf/open/floor/engine,
 /area/science)
 "Nh" = (
 /turf/open/space/basic,
@@ -12038,7 +12215,7 @@
 	name = "Escape Shuttle Dock"
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/monotile/dark,
+/turf/open/floor/plating/airless,
 /area/hallway/secondary/exit/departure_lounge)
 "NH" = (
 /obj/structure/stairs{
@@ -12368,15 +12545,14 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "OD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/window/reinforced,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/engine,
 /area/science)
 "OE" = (
 /obj/machinery/camera{
@@ -12667,10 +12843,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/monotile/dark,
+/turf/open/floor/monotile/steel,
 /area/science)
 "Px" = (
 /obj/machinery/camera/autoname{
@@ -12803,6 +12976,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
+"PW" = (
+/obj/machinery/holopad,
+/turf/open/floor/monotile/steel,
+/area/engine/engine_room)
 "PX" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/structure/disposalpipe/segment{
@@ -12881,6 +13058,13 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/chapel/main)
+"Qi" = (
+/obj/effect/turf_decal/tile/ship/half/yellow,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/monotile/dark,
+/area/engine/engine_room)
 "Qk" = (
 /obj/effect/turf_decal/tile/ship/half/orange{
 	dir = 4
@@ -12950,6 +13134,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "Qw" = (
@@ -12989,6 +13176,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
@@ -13166,6 +13356,9 @@
 	dir = 9
 	},
 /obj/machinery/light,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/tech/grid,
 /area/hallway/nsv/deck2/primary)
 "Rb" = (
@@ -13183,6 +13376,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
@@ -13425,7 +13621,7 @@
 /obj/vehicle/ridden/janicart,
 /obj/item/key/janitor,
 /obj/effect/turf_decal/ship/techfloor,
-/obj/machinery/light/small/broken,
+/obj/machinery/light/small,
 /turf/open/floor/durasteel/lino,
 /area/janitor)
 "RS" = (
@@ -13434,6 +13630,9 @@
 	},
 /obj/effect/turf_decal/tile/ship/half/orange{
 	dir = 1
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/gauss/battery/deck2/starboard)
@@ -13557,14 +13756,10 @@
 	name = "Abandoned Bar"
 	})
 "Sk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1;
-	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
-	},
-/turf/open/floor/circuit/telecomms,
-/area/science)
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "Sl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -13593,7 +13788,7 @@
 	dir = 4
 	},
 /obj/structure/sign/nanotrasen{
-	pixel_y = 26
+	pixel_y = 32
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -13602,6 +13797,9 @@
 	dir = 1
 	},
 /obj/structure/closet/radiation,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "Ss" = (
@@ -13651,6 +13849,10 @@
 /obj/item/trash/raisins,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
+"SE" = (
+/obj/machinery/holopad,
+/turf/open/floor/monotile/dark,
+/area/nsv/weapons)
 "SF" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/status_display/ai/south,
@@ -13665,7 +13867,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/chem_master,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/monotile/dark,
 /area/science)
 "SJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -13684,12 +13886,6 @@
 "SM" = (
 /obj/structure/cable{
 	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/monotile/steel,
@@ -13733,13 +13929,10 @@
 /turf/open/floor/carpet/ship,
 /area/nsv/weapons)
 "SV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	external_pressure_bound = 140;
-	name = "killroom vent";
-	pressure_checks = 0
-	},
-/turf/open/floor/circuit/telecomms,
-/area/science)
+/obj/structure/lattice/catwalk,
+/obj/structure/railing,
+/turf/open/space/basic,
+/area/space/nearstation)
 "SW" = (
 /obj/machinery/fax{
 	fax_name = "Wardens Office";
@@ -13816,12 +14009,12 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "Th" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	external_pressure_bound = 120;
-	name = "server vent"
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
 	},
-/turf/open/floor/circuit/telecomms,
-/area/science)
+/turf/open/space/basic,
+/area/space/nearstation)
 "Tj" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -14265,6 +14458,12 @@
 /obj/structure/closet/crate,
 /obj/item/stack/ore/copper,
 /obj/effect/turf_decal/tile/ship/half/neutral,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
 "UE" = (
@@ -14334,6 +14533,14 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/quartermaster/storage)
+"UJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/science)
 "UK" = (
 /obj/structure/overmap/small_craft/combat/light,
 /turf/open/floor/plasteel/techmaint{
@@ -14376,9 +14583,6 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "UR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/machinery/status_display/ai/north,
 /obj/machinery/light{
@@ -14456,13 +14660,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "Vl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/chair/office/light{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 5
 	},
 /turf/open/floor/monotile/dark,
@@ -14690,6 +14891,7 @@
 	id = "dispo";
 	name = "Disposal Shutter"
 	},
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "VZ" = (
@@ -14840,6 +15042,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/orange,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
 "Wy" = (
@@ -14863,7 +15068,8 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/space/nearstation)
 "WD" = (
 /obj/structure/overmap/small_craft/transport/sabre,
@@ -14908,6 +15114,17 @@
 "WN" = (
 /turf/closed/wall/r_wall,
 /area/security/brig)
+"WP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/science)
 "WQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -14965,16 +15182,11 @@
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
 "Xc" = (
-/obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/general/hidden,
-/turf/open/floor/circuit/telecomms,
-/area/science)
+/turf/open/floor/durasteel/techfloor,
+/area/maintenance/nsv/deck2/port)
 "Xd" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Arrivals"
@@ -15028,6 +15240,7 @@
 /area/ai_monitored/security/armory)
 "Xp" = (
 /obj/effect/landmark/start/cargo_technician,
+/obj/machinery/holopad,
 /turf/open/floor/monotile/steel,
 /area/quartermaster/storage)
 "Xt" = (
@@ -15333,6 +15546,12 @@
 /obj/item/papercutter,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
+"Yu" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "Yv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15460,6 +15679,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "YW" = (
@@ -15543,6 +15765,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/grid/steel,
 /area/hallway/secondary/exit/departure_lounge)
 "Zm" = (
@@ -15644,11 +15867,19 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "ZC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1;
+	external_pressure_bound = 140;
+	name = "server vent";
+	pressure_checks = 0
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/window/brigdoor{
+	name = "Creature Pen";
+	req_access_txt = "47"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/circuit/telecomms,
 /area/science)
 "ZF" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -15680,6 +15911,18 @@
 /obj/item/clothing/mask/surgical,
 /turf/open/floor/plasteel/techmaint,
 /area/science)
+"ZL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "ZM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15758,7 +16001,10 @@
 /area/nsv/weapons)
 "ZT" = (
 /obj/machinery/smartfridge/extract/preloaded,
-/turf/closed/wall/r_wall,
+/obj/machinery/light_switch/east{
+	pixel_x = 22
+	},
+/turf/open/floor/plasteel/techmaint,
 /area/science)
 "ZW" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -36744,8 +36990,8 @@ ms
 jZ
 Hl
 Ds
-xi
-xi
+an
+an
 an
 Nh
 Nh
@@ -37002,7 +37248,7 @@ jZ
 jZ
 Ei
 pQ
-xi
+an
 an
 Nh
 Nh
@@ -40571,7 +40817,7 @@ Nh
 Nh
 Nh
 Nh
-an
+SV
 Nh
 Nh
 Nh
@@ -40609,7 +40855,7 @@ Nh
 Nh
 Nh
 Nh
-an
+Th
 Nh
 Nh
 Nh
@@ -40828,7 +41074,7 @@ Nh
 Nh
 Nh
 Nh
-an
+SV
 ZA
 ZA
 Et
@@ -40866,7 +41112,7 @@ Nh
 ZA
 ZA
 Et
-an
+Th
 Nh
 Nh
 Nh
@@ -41085,7 +41331,7 @@ Nh
 Nh
 Nh
 Nh
-an
+SV
 ZA
 ZA
 ZA
@@ -41123,7 +41369,7 @@ kW
 ZA
 ZA
 ZA
-an
+Th
 Nh
 Nh
 Nh
@@ -41342,7 +41588,7 @@ Nh
 Nh
 Nh
 Nh
-an
+SV
 gS
 gS
 gS
@@ -41380,7 +41626,7 @@ gS
 gS
 gS
 gS
-an
+Th
 Nh
 Nh
 Nh
@@ -41599,7 +41845,7 @@ Nh
 Nh
 Nh
 Nh
-an
+bz
 hG
 hG
 hG
@@ -41637,7 +41883,7 @@ hg
 hg
 hg
 hg
-an
+DL
 Nh
 Nh
 Nh
@@ -42627,7 +42873,7 @@ Nh
 Nh
 an
 kH
-bh
+Yu
 rE
 kH
 xS
@@ -43158,13 +43404,13 @@ MO
 cB
 Vi
 oz
-oz
+PW
 Yy
 nB
 ul
 mp
 Um
-Vi
+Qi
 MO
 NP
 Jk
@@ -43436,8 +43682,8 @@ mL
 mL
 mL
 mL
-an
-Nh
+ms
+ms
 Nh
 Nh
 Nh
@@ -43693,14 +43939,14 @@ qd
 nL
 fe
 VY
-xi
 ms
-jy
-jy
-aj
-aj
-aj
-jy
+ms
+Nh
+ms
+ms
+ms
+Nh
+Nh
 Nh
 Nh
 Nh
@@ -43919,7 +44165,7 @@ CE
 Al
 bs
 dl
-dl
+ZL
 Ri
 iD
 nq
@@ -43950,13 +44196,13 @@ Ie
 yr
 Vz
 mL
-xi
-Nh
 ms
-Nh
-Nh
-ms
-Nh
+jy
+jy
+jy
+jy
+jy
+jy
 aj
 Nh
 Nh
@@ -44207,10 +44453,10 @@ ca
 vJ
 Vz
 mL
-xi
-an
-an
-an
+ms
+Nh
+ms
+ms
 Nh
 Yi
 ms
@@ -44464,7 +44710,7 @@ sP
 zq
 Qc
 mL
-xi
+Sk
 Zb
 ns
 ns
@@ -44721,7 +44967,7 @@ sP
 mL
 vw
 mL
-xi
+mL
 Nb
 Nb
 Nb
@@ -44956,7 +45202,7 @@ rQ
 nO
 Tg
 kL
-mv
+tF
 am
 ps
 tm
@@ -44976,9 +45222,9 @@ YQ
 XL
 Ie
 LJ
-bq
+Gq
 mL
-kD
+mL
 Zb
 ns
 ns
@@ -45235,7 +45481,7 @@ YQ
 Ie
 Oc
 mL
-kD
+mL
 Nb
 Nb
 Nb
@@ -45492,7 +45738,7 @@ YQ
 Ie
 qG
 mL
-kD
+mL
 Zb
 ns
 ns
@@ -45724,7 +45970,7 @@ zY
 zY
 dP
 kt
-Ef
+BH
 zI
 lW
 bx
@@ -45749,7 +45995,7 @@ ks
 gl
 nI
 mL
-kD
+mL
 Nb
 Nb
 Nb
@@ -46006,7 +46252,7 @@ YQ
 Ie
 Uz
 mL
-kD
+mL
 Zb
 ns
 ns
@@ -47266,7 +47512,7 @@ jb
 jr
 jY
 VJ
-ny
+Fu
 RN
 nZ
 jh
@@ -47519,7 +47765,7 @@ Xv
 Om
 hL
 in
-ir
+Xc
 wd
 Sz
 SX
@@ -48294,7 +48540,7 @@ ir
 wd
 ef
 un
-Ef
+BH
 RN
 jI
 jh
@@ -48306,7 +48552,7 @@ OY
 pH
 jP
 RN
-Jz
+aN
 un
 ut
 Eo
@@ -48539,7 +48785,7 @@ kn
 kn
 Yp
 kH
-iC
+vt
 qx
 dC
 jA
@@ -48549,7 +48795,7 @@ hL
 mO
 ir
 wd
-WH
+tC
 un
 ny
 RN
@@ -49304,7 +49550,7 @@ kD
 kH
 Hc
 bh
-bh
+si
 bh
 jN
 bh
@@ -49322,7 +49568,7 @@ Tx
 jv
 zX
 tk
-Ef
+BH
 RN
 KG
 pH
@@ -49848,7 +50094,7 @@ Se
 pH
 EB
 RN
-Ss
+IR
 un
 ny
 IW
@@ -50335,7 +50581,7 @@ LU
 wl
 kB
 aC
-aC
+MD
 Aa
 aW
 TP
@@ -50626,7 +50872,7 @@ hX
 OW
 LD
 OW
-OW
+Lq
 jF
 yq
 BX
@@ -52670,7 +52916,7 @@ mP
 mP
 mP
 Te
-mP
+SE
 mP
 mP
 gc
@@ -53195,7 +53441,7 @@ eY
 eY
 Qg
 Fm
-tp
+vr
 Mi
 Gh
 kg
@@ -53676,7 +53922,7 @@ iV
 sh
 sh
 SS
-sh
+ae
 VC
 sh
 KH
@@ -53959,11 +54205,11 @@ kQ
 kQ
 mP
 ct
-mP
+GW
 eY
-vr
 tp
-pX
+tp
+da
 ln
 vl
 uL
@@ -54219,7 +54465,7 @@ ct
 Md
 eY
 OE
-jS
+tp
 Nf
 cz
 id
@@ -54476,7 +54722,7 @@ ct
 Gm
 eY
 oM
-LF
+LZ
 OD
 en
 Pt
@@ -54733,10 +54979,10 @@ ct
 tX
 eY
 pX
-Lq
+jS
 vG
-Mi
-si
+GX
+td
 kV
 sn
 vv
@@ -54990,16 +55236,16 @@ ct
 mP
 eY
 LZ
-SV
+LZ
 Ji
 GX
-kI
+td
 hV
 JB
 zH
 lB
 yN
-sn
+WP
 Mi
 Pm
 uc
@@ -55242,15 +55488,15 @@ ea
 lt
 gD
 JP
-Te
+kI
 ct
 mP
 eY
 LG
-Th
-Xc
-MD
-bz
+tp
+Nf
+GX
+td
 SM
 ep
 sJ
@@ -55508,7 +55754,7 @@ fu
 iQ
 KK
 Vl
-BH
+px
 ua
 px
 ku
@@ -55760,10 +56006,10 @@ he
 ZW
 rO
 eY
-pX
+hh
 dU
 ZC
-Mi
+Iy
 Gd
 fZ
 ZT
@@ -56017,9 +56263,9 @@ iE
 nn
 Nd
 gO
-Th
-Ez
-Sk
+sn
+LF
+sn
 Mi
 Mi
 Mi
@@ -56275,8 +56521,8 @@ MF
 Nk
 eY
 km
-LZ
-km
+Ez
+BS
 Mi
 fI
 Jb
@@ -56793,7 +57039,7 @@ Qp
 uI
 IZ
 bv
-bv
+UJ
 FG
 NX
 Vv

--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -4566,12 +4566,10 @@
 "ok" = (
 /obj/machinery/monkey_recycler,
 /obj/structure/extinguisher_cabinet/north{
-	pixel_y = 0;
 	pixel_x = 39
 	},
 /obj/structure/extinguisher_cabinet/north{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/science)
@@ -13784,11 +13782,6 @@
 /area/crew_quarters/abandoned_gambling_den{
 	name = "Abandoned Bar"
 	})
-"Sk" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "Sl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -44744,7 +44737,7 @@ sP
 zq
 Qc
 mL
-Sk
+ms
 Zb
 ns
 ns

--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -172,7 +172,6 @@
 	},
 /obj/machinery/camera/autoname,
 /obj/structure/extinguisher_cabinet/north,
-/obj/machinery/droneDispenser/preloaded,
 /turf/open/floor/monotile/steel,
 /area/science)
 "aw" = (
@@ -509,6 +508,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
 "bC" = (
@@ -520,12 +522,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
 "bG" = (
-/obj/effect/turf_decal/tile/ship/half/yellow{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/ship/half/yellow,
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
@@ -546,18 +549,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
-"bJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
 "bK" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -630,9 +621,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/landmark/start/janitor,
 /obj/structure/chair/noose,
-/obj/effect/decal/remains/human{
-	name = "Joe Czanek"
-	},
 /obj/machinery/requests_console{
 	department = "Custodial Closet";
 	departmentType = 2;
@@ -647,14 +635,17 @@
 /area/maintenance/nsv/deck2/port)
 "cn" = (
 /obj/machinery/light_switch/west,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/durasteel/techfloor,
 /area/maintenance/nsv/deck2/starboard)
 "cp" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/effect/decal/cleanable/robot_debris,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/auto_name/north,
-/obj/effect/decal/cleanable/robot_debris,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "cs" = (
@@ -679,9 +670,6 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "cv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/landmark/start/chaplain,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -763,7 +751,6 @@
 /turf/open/floor/plating,
 /area/science)
 "cB" = (
-/obj/effect/turf_decal/pool,
 /obj/machinery/power/port_gen/pacman,
 /obj/item/stack/cable_coil,
 /obj/machinery/requests_console{
@@ -772,12 +759,13 @@
 	name = "Engineering RC";
 	pixel_y = 26
 	},
-/turf/open/floor/monotile/dark,
-/area/engine/engine_room)
-"cD" = (
 /obj/effect/turf_decal/tile/ship/half/yellow{
 	dir = 1
 	},
+/turf/open/floor/monotile/dark,
+/area/engine/engine_room)
+"cD" = (
+/obj/effect/turf_decal/tile/ship/half/yellow,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/rnd/production/techfab/department/engineering,
 /turf/open/floor/monotile/dark,
@@ -835,11 +823,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "4-9"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
@@ -892,14 +880,8 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons/gauss/battery/deck2/port)
 "dh" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
@@ -1011,11 +993,14 @@
 /area/maintenance/nsv/deck2/starboard)
 "dy" = (
 /obj/machinery/light/small,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
@@ -1034,21 +1019,6 @@
 "dC" = (
 /turf/closed/wall/r_wall,
 /area/nsv/weapons/gauss/battery/deck2/port)
-"dE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6-9"
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/primary)
 "dF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -1438,22 +1408,9 @@
 /turf/open/floor/carpet/orange,
 /area/engine/engine_room)
 "eO" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit/departure_lounge)
 "eR" = (
 /obj/item/trash/chips,
 /turf/open/floor/plating,
@@ -1779,9 +1736,11 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "fP" = (
-/obj/effect/turf_decal/pool,
 /obj/machinery/suit_storage_unit/engine,
 /obj/machinery/status_display/evac/east,
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "fS" = (
@@ -2146,22 +2105,9 @@
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "gU" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/quartermaster/miningoffice)
 "gV" = (
 /obj/machinery/atmospherics/pipe/manifold/general/hidden/layer2{
 	dir = 1
@@ -2604,9 +2550,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/ship/half/yellow{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/ship/half/yellow,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -3592,17 +3536,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
-"le" = (
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
 "lf" = (
 /obj/structure/rack,
 /obj/item/powder_bag{
@@ -3680,9 +3613,7 @@
 /turf/open/floor/monotile/dark,
 /area/science)
 "lo" = (
-/obj/effect/turf_decal/tile/ship/half/yellow{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/ship/half/yellow,
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -3851,8 +3782,9 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/hallway/nsv/deck2/primary)
 "lK" = (
-/obj/item/control_rod,
-/turf/open/indestructible/sound/pool/spentfuel/wall,
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/tile/ship/half/yellow,
+/turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "lL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -4017,16 +3949,11 @@
 /area/space/nearstation)
 "mt" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/port)
 "mv" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
@@ -4087,19 +4014,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
-"mE" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
 "mG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -4114,9 +4028,11 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "mH" = (
-/obj/item/control_rod,
-/turf/open/indestructible/sound/pool/spentfuel,
-/area/engine/engine_room)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/starboard)
 "mJ" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plating,
@@ -4312,10 +4228,7 @@
 "ns" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -4568,9 +4481,6 @@
 /turf/open/floor/monotile/steel,
 /area/engine/engine_room)
 "oh" = (
-/obj/effect/turf_decal/pool{
-	dir = 1
-	},
 /obj/effect/landmark/start/depsec/engineering,
 /obj/machinery/light_switch/east,
 /turf/open/floor/monotile/steel,
@@ -4602,6 +4512,12 @@
 /obj/machinery/vending/engivend,
 /obj/machinery/status_display/ai/north{
 	pixel_y = 26
+	},
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 1
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
@@ -5008,6 +4924,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "po" = (
@@ -5345,6 +5264,9 @@
 "qe" = (
 /obj/machinery/vending/tool,
 /obj/machinery/computer/ship/viewscreen,
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "qf" = (
@@ -5369,6 +5291,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/zebra_interlock_point,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/maintenance/nsv/deck2/starboard)
 "qj" = (
@@ -5408,6 +5333,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -5501,7 +5429,7 @@
 "qL" = (
 /obj/machinery/power/solar_control,
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
@@ -5706,9 +5634,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/pool/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 1
+	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "rB" = (
@@ -5849,6 +5779,9 @@
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
 "rT" = (
@@ -5964,6 +5897,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "sl" = (
@@ -6158,15 +6095,11 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "sY" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/durasteel/techfloor,
+/area/maintenance/nsv/deck2/starboard)
 "td" = (
 /turf/open/floor/monotile/steel,
 /area/science)
@@ -6302,15 +6235,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/security/brig)
-"tt" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "tu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -6444,12 +6368,18 @@
 /turf/closed/wall/r_wall,
 /area/quartermaster/storage)
 "tQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/port)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "tR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -6511,9 +6441,6 @@
 /turf/open/floor/monotile/steel/airless,
 /area/nsv/hanger/mining)
 "ud" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/ship/hatch{
 	name = "Chapel Office";
 	req_one_access_txt = "22"
@@ -6537,10 +6464,12 @@
 /turf/open/floor/monotile/dark,
 /area/chapel/main)
 "ue" = (
-/obj/structure/cable/yellow,
 /obj/machinery/power/solar{
 	id = "starboardsolar";
 	name = "Starboard Solar Array"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
@@ -6578,6 +6507,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/zebra_interlock_point,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "ul" = (
@@ -6675,9 +6607,6 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "uv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -6844,21 +6773,14 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
-"uR" = (
+"uU" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
-"uU" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/space/basic,
 /area/space/nearstation)
 "uW" = (
 /obj/effect/turf_decal/tile/orange{
@@ -6934,16 +6856,20 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "vj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "vl" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6957,9 +6883,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/ship/half/yellow{
-	dir = 8
-	},
+/obj/effect/turf_decal/tile/ship/half/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -6986,11 +6910,9 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "vr" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck2/starboard)
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/turf/open/floor/engine,
+/area/science)
 "vs" = (
 /obj/structure/sign/directions/science,
 /obj/structure/sign/directions/security{
@@ -7039,15 +6961,10 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/gauss/battery/deck2/starboard)
 "vD" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/science)
 "vE" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -7190,9 +7107,7 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "vY" = (
-/obj/effect/turf_decal/tile/ship/half/yellow{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/ship/half/yellow,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -7200,7 +7115,7 @@
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "vZ" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den{
 	name = "Abandoned Bar"
@@ -7348,17 +7263,6 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/nsv/weapons)
-"wG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "6-9"
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/primary)
 "wJ" = (
 /obj/machinery/conveyor/slow{
 	dir = 4;
@@ -7481,7 +7385,10 @@
 /area/nsv/hanger/notkmcstupidhanger)
 "xa" = (
 /obj/structure/cable{
-	icon_state = "6-8"
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -7529,9 +7436,6 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "xm" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
@@ -7757,23 +7661,6 @@
 	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
-"xW" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
 "xX" = (
 /obj/structure/reagent_dispensers/fueltank/cryogenic_fuel,
 /obj/item/radio/intercom/directional/north,
@@ -7911,9 +7798,6 @@
 	},
 /area/nsv/hanger/notkmcstupidhanger)
 "yC" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -8588,13 +8472,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
-"AV" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/tracker,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "AW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -8665,11 +8542,12 @@
 /turf/open/floor/monotile/dark,
 /area/science)
 "Bp" = (
-/obj/item/control_rod,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/indestructible/sound/pool/spentfuel/wall,
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/effect/turf_decal/tile/ship/half/yellow,
+/turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "Br" = (
 /obj/machinery/light,
@@ -9099,9 +8977,6 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "CS" = (
-/obj/effect/turf_decal/pool{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -9131,8 +9006,7 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "Db" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/six,
+/obj/machinery/droneDispenser/preloaded,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "Dc" = (
@@ -9207,20 +9081,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/nsv/deck2/primary)
-"Dp" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
 "Dq" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -9269,10 +9129,10 @@
 /area/hallway/nsv/deck2/primary)
 "Dw" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "1-2"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -9351,9 +9211,6 @@
 	},
 /area/nsv/hanger/notkmcstupidhanger)
 "DZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/ship/maintenance{
 	req_one_access_txt = "22"
 	},
@@ -9434,20 +9291,6 @@
 "Ei" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
-"Ej" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
 "Ek" = (
 /obj/structure/cable{
@@ -9846,17 +9689,13 @@
 /turf/open/floor/engine,
 /area/nsv/weapons)
 "FQ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/space/basic,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "FR" = (
 /obj/structure/closet/crate/bin,
@@ -9923,18 +9762,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/science)
-"Ge" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "Gf" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -9964,15 +9791,6 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/science)
-"Gi" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "Gj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -10019,20 +9837,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
-"Gq" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
 "Gs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -10286,11 +10090,11 @@
 /area/hallway/nsv/deck2/primary)
 "Hi" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/grille,
+/obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
-/area/maintenance/nsv/deck2/port)
+/area/maintenance/nsv/deck2/starboard)
 "Hl" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating/airless,
@@ -10647,10 +10451,7 @@
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "IG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "II" = (
@@ -10944,14 +10745,8 @@
 /obj/machinery/power/smes{
 	charge = 5e+006
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/structure/cable{
-	icon_state = "0-6"
-	},
-/obj/structure/cable{
-	icon_state = "6-9"
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
@@ -11064,20 +10859,23 @@
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 4
 	},
-/obj/item/cigbutt,
 /obj/item/cigbutt{
-	pixel_x = 5;
-	pixel_y = -3
+	pixel_y = -7;
+	pixel_x = -7
 	},
 /obj/item/cigbutt{
-	pixel_x = 12;
-	pixel_y = 6
+	pixel_x = 2;
+	pixel_y = -3
 	},
 /obj/item/storage/fancy/cigarettes{
 	desc = "These taste terrible, but they'll help you manage a community.";
 	name = "\improper Community Manager's Cigarettes"
 	},
 /obj/machinery/light_switch/east,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
 /turf/open/floor/durasteel/lino,
 /area/janitor)
 "JX" = (
@@ -11228,15 +11026,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
-"Kq" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "Kt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating{
@@ -11273,15 +11062,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "KD" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/durasteel/techfloor,
+/area/maintenance/nsv/deck2/starboard)
 "KE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -11387,22 +11172,6 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science)
-"KV" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
 "KW" = (
 /obj/machinery/flasher{
 	id = "isolation";
@@ -11527,17 +11296,22 @@
 /turf/open/floor/engine,
 /area/quartermaster/storage)
 "Ll" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "Lm" = (
 /obj/structure/chair{
 	dir = 1
@@ -11564,18 +11338,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/chapel/main)
-"Ls" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "Lt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -11628,15 +11390,6 @@
 	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
-"LA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/half/yellow{
-	dir = 1
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/primary)
 "LC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -11688,9 +11441,6 @@
 /turf/open/floor/circuit/telecomms,
 /area/science)
 "LH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -11815,9 +11565,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/ship/half/yellow{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/ship/half/yellow,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -12165,13 +11913,12 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "Nb" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow,
 /obj/machinery/power/solar{
 	id = "starboardsolar";
 	name = "Starboard Solar Array"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
@@ -12202,16 +11949,6 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/dark,
 /area/science)
-"Ng" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
 "Nh" = (
 /turf/open/space/basic,
 /area/space)
@@ -12273,9 +12010,6 @@
 	name = "Abandoned Bar"
 	})
 "NC" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-9"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -12283,6 +12017,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
 "ND" = (
@@ -12311,9 +12048,7 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "NI" = (
-/obj/effect/turf_decal/tile/ship/half/yellow{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/ship/half/yellow,
 /obj/machinery/light,
 /obj/machinery/computer/rdconsole/production{
 	dir = 1
@@ -12368,9 +12103,6 @@
 /turf/open/floor/plasteel/techmaint,
 /area/nsv/weapons)
 "NT" = (
-/obj/effect/turf_decal/pool{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -12458,22 +12190,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
-"Of" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
 "Og" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -13035,19 +12751,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/monotile/steel,
 /area/security/brig)
-"PP" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
 "PQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -13170,9 +12873,6 @@
 /turf/open/floor/engine,
 /area/science)
 "Qh" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -13247,9 +12947,6 @@
 	},
 /obj/effect/turf_decal/ship/delivery/yellow,
 /obj/effect/landmark/zebra_interlock_point,
-/obj/structure/cable/yellow{
-	icon_state = "6-9"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -13484,6 +13181,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "Rg" = (
@@ -13542,15 +13242,6 @@
 /obj/structure/sign/departments/evac,
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/exit/departure_lounge)
-"Rp" = (
-/obj/effect/turf_decal/pool/corner{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/monotile/steel,
-/area/engine/engine_room)
 "Rq" = (
 /obj/machinery/door/airlock/highsecurity/ship{
 	name = "Munitions Projects";
@@ -13574,11 +13265,9 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "Rr" = (
-/obj/effect/turf_decal/pool{
-	dir = 1
-	},
-/turf/open/floor/monotile/steel,
-/area/engine/engine_room)
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck2/starboard)
 "Rs" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
 	dir = 8
@@ -14134,10 +13823,7 @@
 /turf/open/floor/circuit/telecomms,
 /area/science)
 "Tj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/starboard)
 "Tk" = (
@@ -14321,9 +14007,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "TG" = (
@@ -14344,19 +14027,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
-"TL" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
 "TN" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -14542,19 +14212,6 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/wood,
 /area/chapel/main)
-"Uq" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
 "Us" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 1
@@ -14563,7 +14220,7 @@
 	dir = 8
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-6"
+	icon_state = "1-2"
 	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
@@ -14750,19 +14407,6 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
-"Va" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
 "Vb" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -14786,24 +14430,8 @@
 /obj/structure/overmap/small_craft/transport/sabre/mining,
 /turf/open/floor/plasteel/techmaint,
 /area/nsv/hanger/mining)
-"Vh" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow,
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
 "Vi" = (
-/obj/effect/turf_decal/tile/ship/half/yellow{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/ship/half/yellow,
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "Vj" = (
@@ -15088,19 +14716,6 @@
 /obj/item/disk/design_disk,
 /turf/open/floor/monotile/dark,
 /area/science)
-"Wc" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
 "Wd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -15130,6 +14745,12 @@
 /area/nsv/weapons)
 "Wf" = (
 /obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/closet/crate,
+/obj/item/control_rod,
+/obj/item/control_rod,
+/obj/item/control_rod,
+/obj/item/control_rod,
+/obj/item/control_rod,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "Wg" = (
@@ -15487,6 +15108,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/ship/blue,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
 "XF" = (
@@ -15496,16 +15120,6 @@
 /obj/machinery/light,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
-"XG" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "XI" = (
 /obj/structure/particle_accelerator/particle_emitter/left{
 	dir = 8
@@ -15690,12 +15304,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "Yq" = (
@@ -15865,29 +15473,10 @@
 /obj/structure/munitions_trolley,
 /turf/open/floor/engine,
 /area/quartermaster/storage)
-"YZ" = (
-/obj/effect/turf_decal/ship/delivery/yellow,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/structure/cable/yellow{
-	icon_state = "6-9"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/primary)
 "Zb" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -38175,7 +37764,7 @@ gS
 gS
 gS
 gS
-AV
+Yi
 gS
 ms
 ms
@@ -38434,11 +38023,11 @@ RW
 Nc
 Dw
 Nc
-kn
-Ws
 uU
-an
-an
+Nc
+uU
+Nc
+Yp
 ms
 jZ
 jZ
@@ -38684,18 +38273,18 @@ gS
 cH
 gS
 gS
-vD
-Ge
-PP
-Ge
-PP
-Ge
 ue
-Ge
-le
 FQ
 ue
-an
+FQ
+ue
+FQ
+ue
+FQ
+ue
+FQ
+ue
+FQ
 ms
 jZ
 ms
@@ -38941,18 +38530,18 @@ gS
 cH
 gS
 gS
-vD
-Ge
-PP
-Ge
-PP
-Ge
 ue
-Ge
-le
 FQ
 ue
-an
+FQ
+ue
+FQ
+ue
+FQ
+ue
+FQ
+ue
+FQ
 ms
 jZ
 jZ
@@ -39198,18 +38787,18 @@ gS
 cH
 gS
 gS
-vD
-Ge
-PP
-Ge
-PP
-Ge
 ue
-Ge
-le
 FQ
 ue
-an
+FQ
+ue
+FQ
+ue
+FQ
+ue
+FQ
+ue
+FQ
 ms
 jZ
 jZ
@@ -39455,18 +39044,18 @@ gS
 gS
 gS
 gS
-vD
-Ge
-PP
-Ge
-PP
-Ge
 ue
-Ge
-le
 FQ
 ue
-an
+FQ
+ue
+FQ
+ue
+FQ
+ue
+FQ
+ue
+FQ
 ms
 ms
 jZ
@@ -39712,18 +39301,18 @@ gS
 cH
 gS
 gS
-vD
-Ge
-PP
-Ge
-PP
-Ge
 ue
-Ge
-le
-Ge
+FQ
 ue
-gS
+FQ
+ue
+FQ
+ue
+FQ
+ue
+FQ
+ue
+FQ
 ms
 jZ
 jZ
@@ -39969,18 +39558,18 @@ gS
 cH
 gS
 gS
-vD
-Ge
-PP
-Ge
-PP
-Ge
 ue
-Ge
-le
-Ge
+FQ
 ue
-gS
+FQ
+ue
+FQ
+ue
+FQ
+ue
+FQ
+ue
+FQ
 ms
 jZ
 AW
@@ -40226,18 +39815,18 @@ gS
 cH
 gS
 gS
-vD
-Ge
-PP
-Ge
-PP
-Ge
 ue
-Ge
-le
-Ge
+FQ
 ue
-gS
+TF
+ue
+TF
+ue
+TF
+ue
+FQ
+ue
+FQ
 ms
 Nh
 uN
@@ -40483,18 +40072,18 @@ gS
 gS
 gS
 gS
-vD
-Ge
-MO
-MO
-MO
-MO
-MO
-Kq
-le
-Ge
 ue
-gS
+FQ
+MO
+MO
+MO
+MO
+MO
+xi
+ue
+FQ
+ue
+FQ
 ms
 ms
 uN
@@ -40740,18 +40329,18 @@ gS
 cH
 gS
 gS
-vD
-Ge
+ue
+FQ
 MO
 bC
 WJ
 bC
 MO
-lO
-le
+xi
+ue
 TF
 ue
-gS
+TF
 Nh
 ms
 uN
@@ -40997,8 +40586,8 @@ gS
 cH
 kD
 kD
-vD
-Gi
+ue
+FQ
 MO
 MO
 dF
@@ -41008,7 +40597,7 @@ MO
 MO
 MO
 MO
-gS
+ms
 ms
 ms
 wz
@@ -41265,7 +40854,7 @@ MO
 Ua
 MO
 MO
-gS
+ms
 Nh
 ms
 hU
@@ -43312,7 +42901,7 @@ iS
 rA
 CS
 NT
-Rp
+NT
 XI
 nA
 BJ
@@ -43567,9 +43156,9 @@ Sf
 Jo
 MO
 cB
-lK
-mH
-Rr
+Vi
+oz
+oz
 Yy
 nB
 ul
@@ -43824,9 +43413,9 @@ kH
 yI
 YQ
 fP
-lK
-mH
-Rr
+Vi
+oz
+oz
 Zh
 mM
 ul
@@ -44082,8 +43671,8 @@ qK
 qI
 oF
 lK
-mH
-Rr
+oz
+oz
 ZH
 VQ
 JD
@@ -44339,7 +43928,7 @@ dQ
 jl
 eL
 Bp
-mH
+oz
 oh
 oz
 UL
@@ -44860,7 +44449,7 @@ vm
 FU
 zG
 Us
-jt
+Us
 uk
 rS
 Je
@@ -44876,11 +44465,11 @@ zq
 Qc
 mL
 xi
-an
-an
-an
-an
-iX
+Zb
+ns
+ns
+ns
+OH
 Nh
 aj
 Nh
@@ -45117,9 +44706,9 @@ Tw
 zY
 zY
 zY
-wG
+zY
 lu
-vd
+tQ
 pl
 Pi
 qN
@@ -45133,10 +44722,10 @@ mL
 vw
 mL
 xi
-Ng
-Ng
-Ng
-Ng
+Nb
+Nb
+Nb
+Nb
 iX
 Nh
 il
@@ -45375,9 +44964,9 @@ kL
 kL
 uq
 mv
-YZ
+Tg
 bD
-un
+vj
 XE
 qI
 Zm
@@ -45390,11 +44979,11 @@ LJ
 bq
 mL
 kD
-XG
+Zb
 ns
 ns
 ns
-sY
+OH
 ms
 aj
 Nh
@@ -45635,7 +45224,7 @@ zI
 zI
 Qv
 kq
-pc
+Ll
 qI
 qI
 Eg
@@ -45647,10 +45236,10 @@ Ie
 Oc
 mL
 kD
-TL
-TL
-TL
-TL
+Nb
+Nb
+Nb
+Nb
 iX
 Nh
 aj
@@ -45891,7 +45480,7 @@ lh
 zI
 zI
 zf
-dE
+un
 bB
 qI
 wb
@@ -45904,11 +45493,11 @@ Ie
 qG
 mL
 kD
-iX
-iX
-iX
-iX
-iX
+Zb
+ns
+ns
+ns
+OH
 Nh
 jy
 Nh
@@ -46161,10 +45750,10 @@ gl
 nI
 mL
 kD
-Va
-Va
-Va
-Va
+Nb
+Nb
+Nb
+Nb
 iX
 ms
 aj
@@ -46375,10 +45964,10 @@ Nh
 Nh
 aj
 Nh
-gS
-gS
-gS
-gS
+pY
+kn
+kn
+Yp
 kH
 ah
 dM
@@ -46418,11 +46007,11 @@ Ie
 Uz
 mL
 kD
-XG
+Zb
 ns
 ns
 ns
-KD
+OH
 Nh
 ms
 Nh
@@ -46632,10 +46221,10 @@ Nh
 Nh
 aj
 ms
-gS
-Wc
-Ej
-vj
+IJ
+Nb
+Nb
+Nb
 kH
 bh
 iw
@@ -46675,10 +46264,10 @@ wR
 jf
 mL
 mL
-TL
-TL
-TL
-TL
+Nb
+Nb
+Nb
+Nb
 iX
 Nh
 aj
@@ -46889,10 +46478,10 @@ Nh
 Nh
 aj
 Nh
-pY
-Ls
-Ls
-tt
+cQ
+kn
+kn
+Yp
 kH
 JY
 kH
@@ -46928,15 +46517,15 @@ uw
 Bh
 sE
 YQ
-Ie
+Rr
 zy
 yC
 Tj
+Zb
+ns
+ns
+ns
 OH
-iX
-iX
-iX
-iX
 ms
 aj
 Nh
@@ -47147,9 +46736,9 @@ Nh
 ms
 Nh
 IJ
-Of
-eO
-Dp
+Nb
+Nb
+Nb
 kH
 bs
 dl
@@ -47186,13 +46775,13 @@ YQ
 YQ
 YQ
 cp
-vr
-mE
+Ie
+bq
 mL
-Va
-Va
-Va
-Va
+Nb
+Nb
+Nb
+Nb
 iX
 Nh
 aj
@@ -47404,9 +46993,9 @@ aj
 aj
 ms
 cQ
-Ll
-Ll
-tt
+kn
+kn
+Yp
 kH
 bt
 dn
@@ -47437,14 +47026,14 @@ un
 Ef
 qI
 cn
-hP
+KD
 sj
-Ie
-Ie
+mH
+mH
 Rf
 xa
 dh
-bJ
+bq
 Tj
 Zb
 ns
@@ -47661,9 +47250,9 @@ Nh
 ms
 Nh
 IJ
-KV
-gU
-Vh
+Nb
+Nb
+Nb
 kH
 bu
 bh
@@ -47693,7 +47282,7 @@ oY
 pn
 qo
 qi
-hP
+sY
 rL
 ob
 ob
@@ -47704,9 +47293,9 @@ JE
 dy
 mL
 Sm
-Sm
-Sm
-Sm
+Nb
+Nb
+Nb
 iX
 ms
 aj
@@ -47918,12 +47507,12 @@ ms
 UE
 Ws
 VS
-Yp
-Yp
+kn
+kn
 Yp
 IG
-iH
-tQ
+iC
+jN
 dC
 eM
 Xv
@@ -47959,7 +47548,7 @@ lG
 ob
 qL
 cT
-Tj
+Hi
 Ws
 Ws
 Ws
@@ -48175,12 +47764,12 @@ Nh
 gS
 gS
 cQ
-Of
-eO
-xW
+Nb
+Nb
+Nb
 kH
 iC
-Hi
+jN
 dC
 uW
 df
@@ -48432,10 +48021,10 @@ aj
 gS
 gS
 SA
-Ll
-Ll
+kn
+kn
+kn
 mt
-IG
 iH
 xm
 dC
@@ -48689,9 +48278,9 @@ aj
 gS
 gS
 IJ
-KV
-gU
-Vh
+Nb
+Nb
+Nb
 kH
 iC
 lZ
@@ -48946,9 +48535,9 @@ Nh
 gS
 gS
 lO
+kn
+kn
 Yp
-Yp
-uR
 kH
 iC
 qx
@@ -49203,8 +48792,8 @@ Nh
 gS
 gS
 gS
-Uq
-Gq
+Nb
+Nb
 Nb
 kH
 iC
@@ -49506,7 +49095,7 @@ AS
 In
 In
 ye
-JT
+eO
 Od
 Nh
 Nh
@@ -49763,7 +49352,7 @@ sq
 ND
 Vj
 Lm
-JT
+eO
 Od
 Nh
 Nh
@@ -50259,7 +49848,7 @@ Se
 pH
 EB
 RN
-LA
+Ss
 un
 ny
 IW
@@ -53351,7 +52940,7 @@ Dy
 Dy
 Dy
 Dy
-sn
+vD
 fc
 oo
 tP
@@ -53620,7 +53209,7 @@ Qs
 De
 cY
 De
-Jq
+gU
 Od
 Nh
 Nh
@@ -53877,7 +53466,7 @@ ar
 wt
 zJ
 ya
-Jq
+gU
 Od
 Nh
 Nh
@@ -54134,7 +53723,7 @@ NN
 wk
 sA
 Ja
-Jq
+gU
 Od
 Nh
 Nh
@@ -54372,7 +53961,7 @@ mP
 ct
 mP
 eY
-tp
+vr
 tp
 pX
 ln
@@ -54905,7 +54494,7 @@ Uy
 DH
 Vy
 zc
-Jq
+gU
 Od
 Nh
 Nh
@@ -55162,7 +54751,7 @@ LX
 DH
 lg
 kx
-Jq
+gU
 Od
 Nh
 Nh
@@ -61314,11 +60903,11 @@ jx
 jx
 QD
 QD
-vZ
+Vm
 ST
 UF
 BQ
-vZ
+Vm
 QD
 pK
 Nh
@@ -61573,8 +61162,8 @@ IK
 vZ
 vZ
 Kg
-vZ
-vZ
+Vm
+Vm
 vZ
 vZ
 pK

--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -6893,6 +6893,10 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 16
+	},
 /turf/open/floor/durasteel/lino,
 /area/janitor)
 "uY" = (
@@ -7943,6 +7947,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
+/obj/item/reagent_containers/syringe/lethal/execution,
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/security/armory)
 "yI" = (

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -73,6 +73,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "aj" = (
@@ -289,11 +290,11 @@
 /turf/open/floor/circuit/red/telecomms,
 /area/tcommsat/server)
 "bk" = (
-/obj/effect/turf_decal/tile/ship/half/green,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/bar/mess_hall)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/hydroponics)
 "bm" = (
 /obj/structure/table/reinforced,
 /obj/item/lighter,
@@ -454,9 +455,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -465,6 +463,7 @@
 	dir = 2;
 	sortType = "19;20"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "ck" = (
@@ -902,6 +901,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "eb" = (
@@ -1805,14 +1805,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
@@ -1937,7 +1937,7 @@
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/plasteel/freezer,
+/turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "iB" = (
 /obj/structure/cable{
@@ -3321,9 +3321,12 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "ok" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck1/port)
+/turf/open/floor/durasteel/techfloor_grid,
+/area/space/nearstation)
 "ol" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3335,15 +3338,15 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "om" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/stool{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
@@ -3589,7 +3592,7 @@
 /area/maintenance/nsv/deck1/port)
 "pA" = (
 /obj/structure/lattice/catwalk/over/ship,
-/obj/machinery/rnd/production/protolathe/department/service,
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
 "pB" = (
@@ -3963,12 +3966,11 @@
 /turf/closed/wall/r_wall,
 /area/hydroponics)
 "rm" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
@@ -4273,7 +4275,7 @@
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 8
 	},
-/obj/machinery/vending/wardrobe/hydro_wardrobe,
+/obj/machinery/rnd/production/protolathe/department/service,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "sE" = (
@@ -4328,6 +4330,9 @@
 "sN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
@@ -7098,7 +7103,7 @@
 "Fm" = (
 /obj/machinery/door/airlock/ship/public/glass{
 	name = "Hydroponics";
-	req_one_access_txt = "35"
+	req_one_access_txt = "35;28;25;26"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -7110,6 +7115,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "Fn" = (
@@ -7872,8 +7878,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
@@ -9776,6 +9780,9 @@
 "PQ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/pill_bottle/dice,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "PR" = (
@@ -10906,12 +10913,6 @@
 "Ve" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/dorms)
-"Vf" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/durasteel/techfloor_grid,
-/area/space/nearstation)
 "Vg" = (
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
@@ -11136,12 +11137,9 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "WD" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/turf/open/floor/monotile/steel,
-/area/crew_quarters/bar/mess_hall)
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/monotile/dark,
+/area/hydroponics)
 "WE" = (
 /obj/effect/decal/cleanable/glitter/white{
 	layer = 4.1;
@@ -45900,8 +45898,8 @@ qO
 HI
 PC
 NK
-XP
-Yj
+WD
+WD
 NK
 YP
 mz
@@ -46672,7 +46670,7 @@ HI
 am
 NK
 Yj
-Yj
+XP
 NK
 YU
 jc
@@ -47701,11 +47699,11 @@ LL
 uN
 KS
 YV
-mW
+bk
 rm
 Iw
-bk
-BE
+cW
+PN
 om
 UU
 UU
@@ -48724,14 +48722,14 @@ pu
 AX
 Nw
 HI
-qf
+LL
 PO
 Oj
 lw
 sJ
 sJ
 ox
-WD
+fs
 cW
 PN
 PN
@@ -48976,12 +48974,12 @@ cL
 cL
 cL
 lx
-Ok
-HW
-Vf
-lx
-HI
 ok
+HW
+oy
+MT
+qf
+LL
 PO
 Oj
 bS

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -1346,16 +1346,15 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 13
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=right";
 	location = "down"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "fD" = (
@@ -1418,9 +1417,6 @@
 /turf/open/openspace,
 /area/maintenance/nsv/deck1/starboard)
 "fR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
@@ -3295,7 +3291,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/ship/half/purple,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -3999,10 +3994,7 @@
 	pixel_y = 30;
 	receive_ore_updates = 1
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
+/obj/machinery/suit_storage_unit/rd,
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/crew_quarters/heads/hor)
 "rt" = (
@@ -7599,7 +7591,6 @@
 	name = "Research Director";
 	req_one_access_txt = "30"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -11583,9 +11574,6 @@
 "Yz" = (
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -242,14 +242,14 @@
 	name = "AI Core SMES";
 	req_one_access_txt = "56"
 	},
-/obj/structure/cable{
-	icon_state = "1-6"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/landmark/zebra_interlock_point,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/durasteel/techfloor,
 /area/ai_monitored/turret_protected/aisat)
 "aZ" = (
@@ -418,7 +418,10 @@
 "ce" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "2-9"
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -574,12 +577,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
-"cQ" = (
-/obj/structure/cable{
-	icon_state = "2-10"
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat)
 "cU" = (
 /obj/machinery/light{
 	dir = 1
@@ -781,16 +778,7 @@
 "dA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-10"
+	icon_state = "1-2"
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -1318,14 +1306,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/structure/chair/office{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8";
+	tag = ""
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
@@ -1398,7 +1387,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "1-8"
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -1539,18 +1528,9 @@
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck1/hallway)
 "gS" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/solar,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/crew_quarters/bar/mess_hall)
 "gU" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -2286,13 +2266,10 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/bar/mess_hall)
 "jZ" = (
-/obj/machinery/power/solar_control{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/machinery/firealarm/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/durasteel/techfloor,
 /area/ai_monitored/turret_protected/aisat)
 "ka" = (
@@ -2310,15 +2287,10 @@
 /turf/open/floor/plating,
 /area/bridge/cic)
 "kc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/landmark/latejoin,
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck1/hallway)
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/ore_silo,
+/turf/open/floor/monotile/dark,
+/area/ai_monitored/nuke_storage)
 "ke" = (
 /obj/effect/turf_decal/tile/ship/brown{
 	dir = 1
@@ -2853,9 +2825,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
@@ -2899,22 +2868,6 @@
 "mz" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/kitchen)
-"mA" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-5"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "mC" = (
 /obj/effect/turf_decal/pool{
 	dir = 1
@@ -3720,12 +3673,9 @@
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
 "qJ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/hallway/nsv/deck1/hallway)
 "qK" = (
 /obj/machinery/holopad,
 /obj/structure/chair/office{
@@ -3996,12 +3946,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/power/terminal{
+	dir = 1
 	},
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-5"
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/durasteel/techfloor,
 /area/ai_monitored/turret_protected/aisat)
@@ -4010,7 +3962,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/ship/green,
-/obj/effect/landmark/latejoin,
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck1/hallway)
 "sd" = (
@@ -4480,19 +4431,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/dorms)
-"uc" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6-8"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "ud" = (
 /obj/item/trash/sosjerky,
 /obj/structure/rack,
@@ -4585,18 +4523,9 @@
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
 "uK" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/power/solar,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/aisat)
 "uN" = (
 /obj/structure/chair{
 	dir = 4
@@ -4680,22 +4609,16 @@
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "uZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "va" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/durasteel/techfloor,
 /area/ai_monitored/turret_protected/aisat)
@@ -4813,15 +4736,17 @@
 /turf/open/floor/monotile/steel,
 /area/medical/medbay)
 "vH" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/machinery/power/terminal{
+	dir = 1
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
+	icon_state = "0-4"
 	},
-/obj/machinery/power/solar,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/durasteel/techfloor,
+/area/ai_monitored/turret_protected/aisat)
 "vI" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -4838,7 +4763,6 @@
 	},
 /area/maintenance/nsv/deck1/port)
 "vK" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/ship/preopen{
 	id = "captainofficeshutters"
 	},
@@ -4846,11 +4770,9 @@
 	dir = 4;
 	id = "atlas_cap"
 	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
+	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/captain)
@@ -5022,22 +4944,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
-"wS" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/power/solar,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
 "wT" = (
 /obj/structure/hull_plate,
 /obj/machinery/light{
@@ -5420,7 +5326,6 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/green,
 /area/hallway/nsv/deck1/hallway)
 "ys" = (
@@ -5491,10 +5396,8 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "yK" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/machinery/power/solar,
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/space/nearstation)
 "yL" = (
@@ -5823,16 +5726,6 @@
 "Am" = (
 /turf/closed/wall/r_wall,
 /area/hallway/nsv/deck1/hallway)
-"An" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/power/solar,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
 "Ao" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5988,7 +5881,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/ship/green,
-/obj/effect/landmark/latejoin,
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck1/hallway)
 "Bl" = (
@@ -6145,13 +6037,13 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/ai_slipper,
 /mob/living/simple_animal/bot/secbot/pingsky,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/carpet/green,
 /area/ai_monitored/turret_protected/aisat)
 "Ca" = (
@@ -6192,15 +6084,9 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Ck" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/recharge_station,
+/turf/open/floor/durasteel/techfloor,
+/area/hallway/nsv/deck1/hallway)
 "Cp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6365,15 +6251,9 @@
 /area/maintenance/nsv/deck1/port)
 "Da" = (
 /obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "0-2"
 	},
 /obj/machinery/power/solar,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -6675,12 +6555,9 @@
 /area/space/nearstation)
 "Ei" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-5"
-	},
+/obj/item/t_scanner,
 /turf/open/floor/durasteel/techfloor,
 /area/ai_monitored/turret_protected/aisat)
 "Ej" = (
@@ -7202,10 +7079,14 @@
 /turf/open/floor/durasteel/lino,
 /area/ai_monitored/nuke_storage)
 "Gx" = (
-/obj/structure/cable{
-	icon_state = "1-10"
-	},
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/autoname{
+	dir = 8
+	},
+/obj/machinery/power/solar_control,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
 /turf/open/floor/durasteel/techfloor,
 /area/ai_monitored/turret_protected/aisat)
 "Gz" = (
@@ -7298,7 +7179,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Hh" = (
@@ -7520,6 +7400,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/power/terminal,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "HW" = (
@@ -7793,6 +7674,7 @@
 /obj/machinery/cryopod{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/green,
 /area/hallway/nsv/deck1/hallway)
 "IX" = (
@@ -8332,6 +8214,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "Lh" = (
@@ -8587,15 +8472,9 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "Mi" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/power/solar,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/medical/medbay)
 "Mo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -9187,12 +9066,11 @@
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/turret_protected/ai_upload)
 "Ow" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "5-10"
+	icon_state = "1-8"
 	},
 /turf/open/floor/durasteel/techfloor,
 /area/ai_monitored/turret_protected/aisat)
@@ -9485,6 +9363,7 @@
 /area/bridge/cic)
 "PT" = (
 /obj/machinery/cryopod,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/green,
 /area/hallway/nsv/deck1/hallway)
 "PX" = (
@@ -9522,9 +9401,6 @@
 /turf/open/floor/carpet/blue,
 /area/bridge/cic)
 "Qd" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/structure/bed/dogbed/ian{
 	color = "";
 	desc = "Skipper's bed! Looks comfy.";
@@ -9803,7 +9679,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/landmark/latejoin,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "RC" = (
@@ -10061,9 +9936,6 @@
 /obj/machinery/light/small{
 	brightness = 3;
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
@@ -10389,9 +10261,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -10406,7 +10275,6 @@
 	},
 /area/maintenance/nsv/deck1/starboard)
 "Uq" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/ship/preopen{
 	id = "captainofficeshutters"
 	},
@@ -10420,6 +10288,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/captain)
 "Uy" = (
@@ -10472,7 +10341,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat)
 "UK" = (
@@ -11075,17 +10944,13 @@
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
 "XT" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/machinery/light/small{
+	dir = 1
 	},
+/obj/machinery/power/smes/engineering,
 /obj/structure/cable{
-	icon_state = "5-10"
+	icon_state = "0-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-5"
-	},
-/obj/item/t_scanner,
 /turf/open/floor/durasteel/techfloor,
 /area/ai_monitored/turret_protected/aisat)
 "XU" = (
@@ -11490,16 +11355,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/morgue)
-"ZZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/power/solar,
-/turf/open/floor/plasteel/airless/solarpanel,
-/area/space/nearstation)
 
 (1,1,1) = {"
 cL
@@ -33481,8 +33336,8 @@ pT
 pT
 pT
 pT
-PG
-An
+Cf
+Cf
 Ax
 Zp
 Ax
@@ -33739,8 +33594,8 @@ bH
 pT
 pT
 pT
-vH
-An
+Cf
+Cf
 Ax
 Ax
 Cf
@@ -33997,7 +33852,7 @@ tk
 pT
 pT
 pT
-Mi
+Cf
 Ax
 cL
 cL
@@ -34254,7 +34109,7 @@ nH
 nf
 pT
 pT
-Mi
+Cf
 Ax
 cL
 cL
@@ -34511,7 +34366,7 @@ Mz
 nH
 JJ
 pT
-Mi
+Cf
 Ax
 Ax
 Ax
@@ -34768,10 +34623,10 @@ Mz
 nH
 lL
 pT
-vH
-ZZ
-ZZ
-ZZ
+Cf
+Cf
+Cf
+PG
 fW
 cL
 cL
@@ -35028,7 +34883,7 @@ pT
 jw
 jw
 jw
-yK
+PG
 Xh
 yK
 Cf
@@ -35285,7 +35140,7 @@ jw
 jw
 jw
 jw
-yK
+PG
 Xh
 yK
 cL
@@ -35542,9 +35397,9 @@ hX
 KM
 iE
 jw
-Mi
+PG
 Xh
-Mi
+yK
 Cf
 Zp
 cL
@@ -35796,12 +35651,12 @@ DX
 gu
 wU
 CT
-CT
+kc
 iE
 jw
-Mi
+PG
 Xh
-Mi
+yK
 cL
 Zp
 cL
@@ -36056,9 +35911,9 @@ CT
 Gh
 Ub
 jw
-Mi
+PG
 Xh
-Mi
+yK
 cL
 Zp
 cL
@@ -36313,9 +36168,9 @@ CT
 BK
 Ud
 jw
-Mi
+PG
 Xh
-Mi
+yK
 Cf
 Zp
 cL
@@ -36570,9 +36425,9 @@ dp
 Hx
 iE
 jw
-Mi
+PG
 Xh
-Mi
+yK
 cL
 cL
 cL
@@ -36827,9 +36682,9 @@ tp
 tp
 tp
 tp
-Mi
-mA
-Mi
+PG
+Xh
+yK
 cL
 bA
 bA
@@ -37081,12 +36936,12 @@ Ly
 wa
 tp
 va
-Ei
-UI
-gS
+vH
+uK
+PG
 dA
-Ck
-Mi
+Xh
+yK
 cL
 bA
 bA
@@ -37339,11 +37194,11 @@ QF
 aY
 Ow
 Ei
-UI
-wS
-uc
-ce
 uK
+PG
+dA
+Xh
+yK
 pW
 pW
 pW
@@ -37593,14 +37448,14 @@ rZ
 ui
 rZ
 sj
-cQ
+tp
 XT
 sb
 UI
 Da
-qJ
+dA
 ce
-Mi
+yK
 pW
 of
 of
@@ -37850,7 +37705,7 @@ rZ
 ui
 TD
 tp
-cQ
+tp
 Gx
 jZ
 tp
@@ -38608,8 +38463,8 @@ qO
 qO
 qO
 YD
-OQ
-KZ
+LL
+LL
 Tb
 uZ
 KZ
@@ -48144,7 +47999,7 @@ RR
 vf
 WJ
 WJ
-DQ
+Mi
 dQ
 dQ
 dQ
@@ -48648,7 +48503,7 @@ mK
 Am
 Am
 PT
-kc
+ST
 sc
 cH
 xT
@@ -49161,7 +49016,7 @@ mK
 Og
 Am
 Am
-Am
+Ck
 ST
 Em
 qP
@@ -49171,7 +49026,7 @@ Em
 TE
 VD
 Em
-TE
+qJ
 cx
 cx
 cx
@@ -50939,9 +50794,9 @@ Oj
 Oj
 Oj
 Oj
-Fl
-Fl
-Fl
+gS
+gS
+gS
 xf
 ag
 xf

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -168,12 +168,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
+"aF" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/port)
 "aJ" = (
 /obj/effect/decal/cleanable/glitter/white{
 	layer = 4.1;
 	name = "smoke"
 	},
 /obj/machinery/light/small,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "aK" = (
@@ -185,6 +194,9 @@
 	dir = 1
 	},
 /obj/machinery/vending/snack/random,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck1/hallway)
 "aO" = (
@@ -290,6 +302,16 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/kitchen)
+"bo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/theatre)
 "bs" = (
 /obj/machinery/computer/ship/viewscreen,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -320,7 +342,7 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "bA" = (
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "bH" = (
 /obj/structure/fluff/bleepypanel{
@@ -423,7 +445,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "cj" = (
 /obj/effect/turf_decal/tile/ship/half/green{
@@ -547,7 +569,7 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "cL" = (
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space)
 "cM" = (
 /obj/machinery/space_heater,
@@ -638,7 +660,7 @@
 	name = "southeast of ship";
 	width = 23
 	},
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "dg" = (
 /obj/structure/cable{
@@ -657,6 +679,12 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"dj" = (
+/obj/structure/chair/fancy/sofa/old/corner/concave{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "dk" = (
 /obj/structure/extinguisher_cabinet/north,
 /obj/structure/closet/secure_closet/bridge,
@@ -680,13 +708,9 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/xo)
 "dn" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "do" = (
 /obj/structure/table/reinforced,
@@ -780,8 +804,19 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
+"dB" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/tile/ship/bar,
+/obj/effect/turf_decal/tile/ship/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/bar{
+	dir = 8
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/bar/mess_hall)
 "dC" = (
 /obj/effect/landmark/start/bridge,
 /obj/structure/chair/office{
@@ -853,10 +888,8 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/xo)
 "dW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/wood,
+/obj/machinery/light/floor,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "dX" = (
 /obj/machinery/vending/boozeomat,
@@ -886,6 +919,10 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
+"ed" = (
+/obj/effect/landmark/start/mime,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/theatre)
 "ee" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -942,10 +979,18 @@
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/aisat)
 "en" = (
-/obj/structure/dresser,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/bar/mess_hall)
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/obj/machinery/light_switch/west,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "ep" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/clonepod/prefilled{
@@ -1043,9 +1088,6 @@
 /turf/open/floor/durasteel/techfloor,
 /area/ai_monitored/turret_protected/aisat)
 "eK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/landmark/start/assistant,
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 4;
@@ -1053,6 +1095,9 @@
 	},
 /obj/structure/chair/stool{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
@@ -1102,9 +1147,14 @@
 /area/bridge/cic)
 "eS" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 9
 	},
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "eZ" = (
 /obj/machinery/computer/robotics{
@@ -1114,6 +1164,9 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/east,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/crew_quarters/heads/hor)
 "fa" = (
@@ -1192,6 +1245,9 @@
 	dir = 8
 	},
 /obj/item/bedsheet/hos,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "fn" = (
@@ -1302,6 +1358,12 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"fD" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/starboard)
 "fF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1389,7 +1451,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "fX" = (
 /obj/structure/cable{
@@ -1431,7 +1493,7 @@
 "gn" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "gq" = (
 /turf/closed/wall/r_wall,
@@ -1451,11 +1513,21 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/durasteel/lino,
 /area/ai_monitored/turret_protected/aisat)
+"gw" = (
+/obj/docking_port/stationary{
+	dwidth = 1;
+	height = 4;
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/openspace/airless,
+/area/space)
 "gy" = (
 /obj/structure/shuttle/engine/huge{
 	dir = 8
 	},
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "gC" = (
 /obj/effect/turf_decal/tile/ship/half/green{
@@ -1567,20 +1639,17 @@
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
@@ -1604,6 +1673,14 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
+"hf" = (
+/obj/effect/landmark/start/clown,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/theatre)
 "hh" = (
 /obj/machinery/holopad,
 /obj/structure/cable{
@@ -1670,6 +1747,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
 "hA" = (
@@ -1682,7 +1762,8 @@
 "hE" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/porta_turret/ai{
-	name = "Anti Air Turret"
+	name = "Anti Air Turret";
+	scan_range = 3
 	},
 /obj/machinery/camera/motion{
 	c_tag = "AI Core Space #1";
@@ -1691,11 +1772,9 @@
 /turf/open/floor/engine/airless,
 /area/ai_monitored/turret_protected/ai)
 "hI" = (
-/obj/structure/extinguisher_cabinet/south,
-/obj/structure/chair/fancy/sofa/old/corner/concave{
-	dir = 8
-	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/ship/half/bar,
+/obj/machinery/light_switch/south,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "hJ" = (
 /turf/open/floor/monotile/dark,
@@ -1823,9 +1902,6 @@
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/structure/extinguisher_cabinet/east,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
@@ -1900,6 +1976,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/structure/bed/roller,
 /turf/open/floor/durasteel/lino,
 /area/medical/medbay)
 "iG" = (
@@ -1963,6 +2040,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -2003,8 +2083,23 @@
 	dir = 4
 	},
 /obj/machinery/newscaster/directional/south,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
+"iV" = (
+/obj/structure/table/wood/fancy,
+/obj/item/camera,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/theatre)
 "iW" = (
 /obj/machinery/light{
 	dir = 1
@@ -2149,6 +2244,14 @@
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
+"js" = (
+/obj/structure/curtain/obscuring/grey,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/theatre)
 "ju" = (
 /turf/open/floor/durasteel/lino,
 /area/tcommsat/server)
@@ -2257,24 +2360,36 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "jX" = (
-/obj/structure/table/wood/fancy,
-/obj/item/camera,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
 	},
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/bar/mess_hall)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "jZ" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/open/floor/durasteel/techfloor,
 /area/ai_monitored/turret_protected/aisat)
 "ka" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
@@ -2308,6 +2423,9 @@
 	density = 0;
 	req_access = null;
 	pixel_x = 32
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
@@ -2348,7 +2466,10 @@
 /area/maintenance/nsv/deck1/central)
 "km" = (
 /obj/machinery/vending/clothing,
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/tile/ship/half/bar{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "kp" = (
 /obj/effect/turf_decal/tile/ship/green,
@@ -2504,9 +2625,6 @@
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
@@ -2578,10 +2696,11 @@
 /turf/open/floor/monotile/dark,
 /area/ai_monitored/turret_protected/ai)
 "le" = (
-/obj/structure/hull_plate,
-/obj/structure/hull_plate,
-/turf/open/floor/engine/airless,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/bar/mess_hall)
 "lf" = (
 /obj/machinery/door/airlock/ship/external/glass{
 	dir = 4;
@@ -2641,6 +2760,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
+"ls" = (
+/obj/effect/turf_decal/tile/ship/half/bar,
+/obj/machinery/light,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/bar/mess_hall)
 "lu" = (
 /obj/structure/fluff/bleepypanel{
 	dir = 8
@@ -2756,13 +2880,11 @@
 /obj/machinery/door/airlock/ship/external/glass{
 	req_one_access_txt = "24"
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "lZ" = (
 /obj/effect/turf_decal/tile/ship/half/yellow{
@@ -2872,7 +2994,7 @@
 /obj/effect/turf_decal/pool{
 	dir = 1
 	},
-/turf/open/floor/monotile/light,
+/turf/open/floor/noslip/darkblue,
 /area/crew_quarters/bar/mess_hall)
 "mE" = (
 /obj/structure/rack,
@@ -2884,6 +3006,18 @@
 	},
 /turf/open/floor/wood,
 /area/security/detectives_office)
+"mH" = (
+/obj/structure/closet/crate/wooden/toy,
+/obj/item/soap/deluxe,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/camera/autoname,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/theatre)
 "mK" = (
 /obj/structure/hull_plate,
 /turf/open/floor/engine/airless,
@@ -2899,6 +3033,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "mN" = (
@@ -2918,6 +3055,9 @@
 	codes_txt = "delivery;dir=4";
 	location = "Medbay";
 	name = "navigation beacon (Medbay Delivery)"
+	},
+/obj/machinery/shower{
+	dir = 4
 	},
 /turf/open/floor/durasteel/alt,
 /area/medical/medbay)
@@ -2951,14 +3091,12 @@
 /turf/open/floor/durasteel/techfloor,
 /area/space/nearstation)
 "na" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	req_one_access_txt = "24"
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/engine,
-/area/maintenance/nsv/deck1/port)
+/turf/open/floor/plating,
+/area/medical/morgue)
 "nf" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/stripes/box,
@@ -2986,10 +3124,11 @@
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat)
 "nk" = (
-/obj/effect/landmark/start/mime,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/bar/mess_hall)
+/obj/structure/chair/fancy/sofa/old{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "nr" = (
 /obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
@@ -3009,6 +3148,9 @@
 /area/bridge/cic)
 "nt" = (
 /obj/effect/spawner/lootdrop/glowstick/lit,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
 /turf/open/floor/durasteel/techfloor,
 /area/space/nearstation)
 "nu" = (
@@ -3109,6 +3251,12 @@
 /obj/structure/sign/ship/deck,
 /turf/closed/wall/steel,
 /area/bridge/cic)
+"nW" = (
+/obj/effect/turf_decal/tile/ship/half/bar{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/bar/mess_hall)
 "nY" = (
 /obj/structure/hull_plate/end{
 	dir = 8
@@ -3159,6 +3307,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/nsv/deck1/starboard)
+"oi" = (
+/obj/structure/chair/fancy/sofa/old/right{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "oj" = (
 /obj/structure/railing{
 	dir = 1
@@ -3224,12 +3378,6 @@
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "ot" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
@@ -3267,7 +3415,7 @@
 /obj/item/pool/rubber_ring,
 /obj/item/pool/rubber_ring,
 /obj/machinery/status_display/ai/west,
-/turf/open/floor/monotile/light,
+/turf/open/floor/noslip/darkblue,
 /area/crew_quarters/bar/mess_hall)
 "oy" = (
 /obj/effect/turf_decal/stripes/line,
@@ -3287,9 +3435,9 @@
 /turf/open/floor/durasteel/techfloor,
 /area/ai_monitored/turret_protected/ai)
 "oD" = (
-/obj/machinery/holopad,
-/turf/open/floor/wood,
-/area/crew_quarters/bar/mess_hall)
+/obj/structure/lattice,
+/turf/open/openspace/airless,
+/area/space)
 "oE" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -3440,10 +3588,8 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/xo)
 "pz" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "pA" = (
@@ -3468,9 +3614,6 @@
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "pG" = (
@@ -3483,10 +3626,19 @@
 /area/hydroponics)
 "pH" = (
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 9
 	},
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/bar/mess_hall)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "pI" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -3531,20 +3683,20 @@
 /turf/template_noop,
 /area/maintenance/nsv/deck1/port)
 "qc" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 1
-	},
 /obj/machinery/advanced_airlock_controller/directional/east,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "qe" = (
-/obj/machinery/vending/autodrobe,
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/bar/mess_hall)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "qf" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -3571,6 +3723,14 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/stool{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
@@ -3615,8 +3775,11 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "qo" = (
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "qs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -3663,7 +3826,7 @@
 	name = "southwest of ship";
 	width = 23
 	},
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "qG" = (
 /obj/structure/hull_plate,
@@ -3743,6 +3906,9 @@
 /obj/machinery/camera/autoname{
 	dir = 10
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/openspace,
 /area/hallway/nsv/deck1/hallway)
 "ra" = (
@@ -3759,6 +3925,9 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/sign/ship/pods/east{
+	pixel_y = -25
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar/mess_hall)
@@ -3779,6 +3948,9 @@
 /area/maintenance/nsv/deck1/port)
 "ri" = (
 /obj/structure/closet/firecloset,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "rj" = (
@@ -3835,7 +4007,7 @@
 /area/crew_quarters/heads/hor)
 "rt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "rv" = (
@@ -3855,8 +4027,8 @@
 /turf/open/floor/durasteel/techfloor,
 /area/ai_monitored/turret_protected/aisat)
 "ry" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/tile/ship/bar,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "rA" = (
 /obj/structure/cable{
@@ -4043,18 +4215,23 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/chief)
+"sr" = (
+/obj/effect/turf_decal/tile/ship/half/bar{
+	dir = 1
+	},
+/obj/machinery/vending/snack/random,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/bar/mess_hall)
 "ss" = (
 /obj/machinery/advanced_airlock_controller/directional/south,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "su" = (
 /obj/effect/turf_decal/tile/ship/green,
@@ -4068,6 +4245,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck1/hallway)
+"sv" = (
+/obj/effect/turf_decal/tile/ship/half/bar{
+	dir = 1
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/bar/mess_hall)
 "sx" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -4243,11 +4427,12 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "tg" = (
-/obj/structure/hull_plate/end{
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/tile/ship/half/bar{
 	dir = 1
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/bar/mess_hall)
 "tj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/wood,
@@ -4261,6 +4446,10 @@
 	},
 /turf/open/floor/bronze,
 /area/ai_monitored/turret_protected/ai)
+"tl" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/dorms)
 "tm" = (
 /obj/machinery/door/airlock/ship/maintenance,
 /obj/machinery/door/firedoor/border_only{
@@ -4465,6 +4654,9 @@
 /obj/machinery/computer/telecomms/server{
 	dir = 4
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/durasteel/lino,
 /area/tcommsat/server)
 "uv" = (
@@ -4499,6 +4691,18 @@
 	},
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
+"uB" = (
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/open/floor/durasteel/alt,
+/area/hallway/nsv/deck1/hallway)
 "uE" = (
 /obj/docking_port/stationary{
 	dheight = 1;
@@ -4508,7 +4712,7 @@
 	name = "northwest of ship";
 	width = 23
 	},
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "uG" = (
 /turf/closed/wall/steel,
@@ -4541,7 +4745,7 @@
 	name = "south of ship";
 	width = 23
 	},
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "uQ" = (
 /obj/machinery/door/airlock/ship/external/glass{
@@ -4641,6 +4845,16 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"ve" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/tile/ship/half/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/bar/mess_hall)
 "vf" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/line{
@@ -4650,8 +4864,16 @@
 /obj/item/storage/firstaid/regular,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/machinery/light,
+/obj/item/roller,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/roller,
 /turf/open/floor/durasteel/lino,
 /area/medical/medbay)
+"vg" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/dorms)
 "vj" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
@@ -4710,6 +4932,11 @@
 /area/tcommsat/server)
 "vy" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "vD" = (
@@ -4794,6 +5021,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/chair/stool{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
@@ -5126,15 +5358,21 @@
 /turf/open/floor/carpet/blue,
 /area/bridge/cic)
 "xu" = (
-/obj/machinery/door/airlock/ship/public/glass{
-	name = "Theatre"
-	},
 /obj/effect/landmark/zebra_interlock_point,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "xv" = (
@@ -5146,6 +5384,9 @@
 	name = "Pegasus"
 	},
 /obj/structure/kitchenspike,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "xw" = (
@@ -5295,6 +5536,12 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/bridge/cic)
+"yj" = (
+/obj/machinery/door/airlock/ship/external{
+	name = "Escape Pod"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/bar/mess_hall)
 "yl" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5383,11 +5630,8 @@
 /turf/open/floor/durasteel/techfloor,
 /area/engine/gravity_generator)
 "yB" = (
-/obj/structure/chair/fancy/sofa/old/left{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/ship/half/bar,
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "yE" = (
 /turf/closed/wall/r_wall,
@@ -5482,8 +5726,18 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/medical_doctor,
+/obj/structure/bed/roller,
 /turf/open/floor/monotile/dark,
 /area/medical/medbay)
+"zo" = (
+/obj/machinery/door/airlock/ship/external/glass{
+	req_one_access_txt = "24"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/port)
 "zt" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -5713,7 +5967,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "Al" = (
 /obj/effect/turf_decal/tile/ship/green,
@@ -5749,12 +6003,16 @@
 /area/crew_quarters/dorms)
 "Ax" = (
 /obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "Ay" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/durasteel/lino,
 /area/medical/medbay)
+"Az" = (
+/obj/structure/curtain/obscuring/grey,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/theatre)
 "AA" = (
 /obj/machinery/telecomms/bus/preset_three,
 /turf/open/floor/circuit/telecomms/server,
@@ -5798,6 +6056,9 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/durasteel/lino,
 /area/medical/medbay)
 "AP" = (
@@ -5814,6 +6075,9 @@
 /obj/effect/turf_decal/tile/ship/half/green,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
 	},
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
@@ -5872,6 +6136,13 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile/dark,
 /area/hydroponics)
+"Bj" = (
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/effect/turf_decal/tile/ship/half/bar,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/bar/mess_hall)
 "Bk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -5885,11 +6156,11 @@
 /area/hallway/nsv/deck1/hallway)
 "Bl" = (
 /obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/durasteel/riveted,
 /area/maintenance/nsv/deck1/port)
@@ -6074,7 +6345,7 @@
 /area/hydroponics)
 "Cf" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "Ch" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -6083,6 +6354,15 @@
 /obj/effect/turf_decal/tile/ship/green,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
+"Ci" = (
+/obj/machinery/door/airlock/ship/maintenance,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/nsv/deck1/port)
 "Ck" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/durasteel/techfloor,
@@ -6114,9 +6394,10 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/chief)
 "Ct" = (
-/obj/structure/chair/stool,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/ship/half/bar{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "Cu" = (
 /obj/machinery/smartfridge/organ,
@@ -6124,11 +6405,26 @@
 /area/medical/medbay)
 "Cw" = (
 /obj/effect/landmark/carpspawn,
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space)
 "Cx" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hor)
+"CB" = (
+/obj/machinery/door/airlock/ship/public/glass{
+	name = "Theatre"
+	},
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "CC" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6356,13 +6652,14 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Dt" = (
-/obj/structure/chair/fancy/sofa/old{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/ship/half/bar,
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/obj/structure/sign/ship/pods/east{
+	pixel_y = -26
+	},
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "Du" = (
 /obj/effect/turf_decal/tile/ship/green,
@@ -6403,7 +6700,7 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
@@ -6615,6 +6912,11 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck1/hallway)
+"Es" = (
+/obj/machinery/vending/autodrobe,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/theatre)
 "Ev" = (
 /obj/machinery/requests_console{
 	department = "Morgue Bay";
@@ -6657,10 +6959,11 @@
 /turf/open/floor/monotile/dark,
 /area/engine/gravity_generator)
 "EC" = (
-/obj/effect/landmark/start/clown,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/bar/mess_hall)
+/obj/structure/chair/fancy/sofa/old/left{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "EE" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -6698,6 +7001,10 @@
 	},
 /turf/open/floor/engine,
 /area/hallway/nsv/deck1/hallway)
+"EO" = (
+/obj/structure/fans/tiny/invisible,
+/turf/open/openspace/airless,
+/area/space)
 "EP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -6828,6 +7135,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
+"Fo" = (
+/obj/structure/musician/piano{
+	icon_state = "piano"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "Fp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6843,7 +7156,10 @@
 	dir = 8
 	},
 /obj/structure/sign/nanotrasen{
-	pixel_y = 26
+	pixel_y = 32
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
@@ -6861,7 +7177,13 @@
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck1/hallway)
 "Fy" = (
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "Fz" = (
 /obj/effect/turf_decal/tile/ship/half/green{
@@ -6920,6 +7242,9 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
+"FK" = (
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/theatre)
 "FL" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/item/reagent_containers/food/snacks/meat/slab,
@@ -6938,17 +7263,21 @@
 /turf/open/floor/engine/airless,
 /area/space)
 "FO" = (
-/obj/structure/closet/crate/wooden/toy,
-/obj/item/soap/deluxe,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/extinguisher_cabinet/west,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/machinery/camera/autoname,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/bar/mess_hall)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "FP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7078,6 +7407,15 @@
 /obj/machinery/computer/bank_machine,
 /turf/open/floor/durasteel/lino,
 /area/ai_monitored/nuke_storage)
+"Gv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/starboard)
 "Gx" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/camera/autoname{
@@ -7119,6 +7457,10 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/nsv/deck1/starboard)
+"GL" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/crew_quarters/theatre)
 "GM" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
@@ -7172,6 +7514,10 @@
 /obj/structure/extinguisher_cabinet/west,
 /turf/open/openspace,
 /area/hallway/nsv/deck1/hallway)
+"Hd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/dorms)
 "Hg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -7289,6 +7635,9 @@
 	c_tag = "Vault";
 	dir = 8
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/durasteel/lino,
 /area/ai_monitored/nuke_storage)
 "Hz" = (
@@ -7300,7 +7649,7 @@
 	name = "northeast of ship";
 	width = 23
 	},
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "HA" = (
 /obj/effect/turf_decal/tile/ship/green{
@@ -7400,7 +7749,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/power/terminal,
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "HW" = (
@@ -7574,6 +7924,10 @@
 /area/engine/gravity_generator)
 "IK" = (
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/medical/morgue)
 "IL" = (
@@ -7810,7 +8164,7 @@
 	name = "north of ship";
 	width = 23
 	},
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "JA" = (
 /obj/structure/bed/dogbed/runtime,
@@ -7836,6 +8190,16 @@
 /obj/machinery/light,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
+"JF" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/solar,
+/obj/machinery/camera/motion{
+	c_tag = "AI - Solars"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/space/nearstation)
 "JG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7854,10 +8218,15 @@
 /obj/effect/landmark/start/ai/secondary,
 /turf/open/floor/bronze,
 /area/ai_monitored/turret_protected/ai)
+"JK" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/openspace/airless,
+/area/space)
 "JL" = (
-/obj/structure/curtain/obscuring/grey,
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/bar/mess_hall)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/theatre)
 "JM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8004,6 +8373,13 @@
 	},
 /turf/open/floor/wood,
 /area/security/detectives_office)
+"Kk" = (
+/obj/structure/hull_plate,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/engine/airless,
+/area/space/nearstation)
 "Km" = (
 /obj/structure/closet/secure_closet/captains,
 /obj/item/hand_tele,
@@ -8024,7 +8400,10 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/tile/ship/half/bar{
+	dir = 4
+	},
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "Ko" = (
 /obj/machinery/hydroponics/constructable,
@@ -8365,8 +8744,8 @@
 	},
 /obj/machinery/power/apc/highcap/fifteen_k{
 	auto_name = 1;
-	dir = 4;
-	pixel_y = 26
+	pixel_y = 23;
+	dir = 1
 	},
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
@@ -8439,10 +8818,16 @@
 /turf/open/floor/monotile/light,
 /area/crew_quarters/kitchen)
 "Ma" = (
-/obj/structure/musician/piano{
-	icon_state = "piano"
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/ship/half/bar{
+	dir = 1
 	},
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "Mb" = (
 /obj/machinery/camera/autoname{
@@ -8599,7 +8984,7 @@
 	dir = 1
 	},
 /obj/structure/sign/nanotrasen{
-	pixel_y = 26
+	pixel_y = 32
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
@@ -8633,6 +9018,17 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname,
+/turf/open/floor/durasteel/alt,
+/area/hallway/nsv/deck1/hallway)
+"MX" = (
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/structure/sign/ship/pods/east{
+	pixel_y = -25
+	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck1/hallway)
 "MZ" = (
@@ -8760,11 +9156,14 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "Ns" = (
 /obj/structure/grille,
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "Nt" = (
 /obj/effect/turf_decal/tile/ship/half/green,
 /obj/machinery/vending/hydronutrients,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "Nu" = (
@@ -8848,8 +9247,31 @@
 /turf/open/floor/monotile/steel,
 /area/medical/medbay)
 "ND" = (
-/turf/open/floor/carpet/blue,
+/obj/structure/chair,
+/obj/effect/turf_decal/tile/ship/bar,
+/obj/effect/turf_decal/tile/ship/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/bar{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
+"NE" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/nsv/deck1/port)
 "NF" = (
 /obj/machinery/door/window/brigdoor/northleft{
 	dir = 4;
@@ -8900,12 +9322,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/bridge/cic)
 "NJ" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck1/port)
+/obj/structure/dresser,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/carpet/blue,
+/area/crew_quarters/theatre)
 "NK" = (
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile/dark,
@@ -8968,13 +9388,14 @@
 "NZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/firecloset,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "Oa" = (
-/obj/structure/curtain/obscuring/grey,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/blue,
-/area/crew_quarters/bar/mess_hall)
+/turf/closed/wall/r_wall,
+/area/crew_quarters/theatre)
 "Od" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/five,
@@ -9195,6 +9616,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "Pe" = (
@@ -9364,12 +9794,20 @@
 "PT" = (
 /obj/machinery/cryopod,
 /obj/effect/landmark/latejoin,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/carpet/green,
 /area/hallway/nsv/deck1/hallway)
 "PX" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck1/port)
+/obj/effect/turf_decal/tile/ship/half/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/bar/mess_hall)
 "PY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -9412,6 +9850,12 @@
 /obj/item/bedsheet/captain,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/captain)
+"Qf" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "Qh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -9421,10 +9865,13 @@
 /turf/open/floor/plating,
 /area/bridge/cic)
 "Qi" = (
-/obj/structure/chair/fancy/sofa/old/right{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "Qk" = (
 /obj/machinery/requests_console{
@@ -9573,6 +10020,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "QT" = (
@@ -9712,8 +10160,11 @@
 /turf/open/floor/monotile/steel,
 /area/ai_monitored/turret_protected/ai_upload)
 "RK" = (
-/obj/machinery/light_switch/south,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/ship/half/bar,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "RL" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -9911,8 +10362,17 @@
 "SP" = (
 /obj/structure/lattice,
 /obj/structure/grille,
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
+"SR" = (
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/effect/turf_decal/tile/ship/half/bar{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/bar/mess_hall)
 "ST" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -9954,12 +10414,6 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
 "Tg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/landmark/start/assistant,
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -9967,6 +10421,14 @@
 	},
 /obj/structure/chair/stool{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
@@ -10032,6 +10494,9 @@
 /area/medical/medbay)
 "Tv" = (
 /obj/structure/closet/radiation,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "Tw" = (
@@ -10235,6 +10700,16 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
+"Uj" = (
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/durasteel/alt,
+/area/hallway/nsv/deck1/hallway)
 "Ul" = (
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 4
@@ -10405,9 +10880,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
@@ -10511,6 +10983,11 @@
 /obj/machinery/door/airlock/ship/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
+"Vw" = (
+/obj/effect/turf_decal/tile/ship/half/bar,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/bar/mess_hall)
 "VA" = (
 /obj/structure/sign/ship/nosmoking,
 /turf/closed/wall/steel,
@@ -10608,6 +11085,13 @@
 /obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/monotile/dark,
 /area/bridge/cic)
+"VX" = (
+/obj/effect/turf_decal/tile/ship/half/bar,
+/obj/machinery/computer/ship/viewscreen{
+	pixel_y = -30
+	},
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/bar/mess_hall)
 "VZ" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -10628,7 +11112,7 @@
 	dir = 4
 	},
 /obj/structure/sign/nanotrasen{
-	pixel_y = 26
+	pixel_y = 32
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
@@ -10638,6 +11122,9 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/carpet/red,
 /area/security/detectives_office)
 "Wv" = (
@@ -10709,7 +11196,7 @@
 	dir = 1
 	},
 /obj/structure/sign/nanotrasen{
-	pixel_y = 26
+	pixel_y = 32
 	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck1/hallway)
@@ -10751,6 +11238,12 @@
 	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck1/hallway)
+"Xe" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/crew_quarters/bar/mess_hall)
 "Xf" = (
 /obj/structure/closet/secure_closet/CMO,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -10780,11 +11273,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "Xi" = (
 /obj/effect/turf_decal/tile/ship/half/green,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "Xl" = (
@@ -10860,11 +11358,13 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "Xx" = (
-/obj/machinery/door/airlock/ship/maintenance,
-/obj/machinery/door/firedoor/border_only/directional/north,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck1/port)
+/obj/structure/chair/stool,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "Xz" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -10930,6 +11430,14 @@
 /obj/machinery/computer/operating,
 /turf/open/floor/plating,
 /area/medical/morgue)
+"XO" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/tile/ship/half/bar{
+	dir = 1
+	},
+/obj/machinery/status_display/evac/north,
+/turf/open/floor/monotile/dark,
+/area/crew_quarters/bar/mess_hall)
 "XP" = (
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/monotile/dark,
@@ -11128,6 +11636,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
+"YJ" = (
+/obj/machinery/holopad,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "YK" = (
 /obj/structure/chair/fancy/shuttle{
 	color = "#696969";
@@ -11178,6 +11690,9 @@
 /obj/machinery/smartfridge/drying_rack,
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/tile/ship/half/green,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "YW" = (
@@ -11220,6 +11735,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/durasteel/riveted,
 /area/maintenance/nsv/deck1/port)
 "Zi" = (
@@ -11242,7 +11760,7 @@
 "Zp" = (
 /obj/structure/grille,
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "Zr" = (
 /obj/effect/turf_decal/tile/ship/green,
@@ -35654,7 +36172,7 @@ CT
 kc
 iE
 jw
-PG
+JF
 Xh
 yK
 cL
@@ -37206,7 +37724,7 @@ pW
 pW
 pW
 pW
-qo
+MS
 gn
 cL
 cL
@@ -37463,7 +37981,7 @@ of
 of
 of
 of
-lx
+MS
 SP
 SP
 cL
@@ -37720,7 +38238,7 @@ Ph
 Ph
 pt
 MS
-qo
+MS
 cL
 SP
 cL
@@ -37977,7 +38495,7 @@ Ph
 Ph
 Ph
 MS
-lx
+MS
 Cf
 SP
 cL
@@ -38234,7 +38752,7 @@ Ph
 Ph
 Ph
 MS
-lx
+MS
 cL
 SP
 cL
@@ -38464,7 +38982,7 @@ qO
 qO
 YD
 LL
-LL
+aF
 Tb
 uZ
 KZ
@@ -38491,7 +39009,7 @@ Ph
 Ph
 Ph
 MS
-lx
+MS
 cL
 SP
 cL
@@ -38748,7 +39266,7 @@ Ph
 Ph
 Ph
 MS
-lx
+MS
 Cf
 SP
 cL
@@ -39005,7 +39523,7 @@ Dd
 MS
 MS
 MS
-lx
+MS
 cL
 cL
 cL
@@ -40001,7 +40519,7 @@ ln
 kZ
 HL
 LL
-iO
+NE
 OU
 Rp
 pc
@@ -40287,10 +40805,10 @@ DA
 mm
 Cx
 pB
-GY
+Gv
 MS
 MS
-lx
+MS
 Rg
 cL
 cL
@@ -40547,7 +41065,7 @@ XG
 vI
 Od
 MS
-lx
+MS
 Rg
 Cf
 cL
@@ -40804,7 +41322,7 @@ MS
 LU
 RD
 MS
-lx
+MS
 Rg
 SP
 cL
@@ -41061,7 +41579,7 @@ Am
 Up
 Ng
 MS
-lx
+MS
 Rg
 SP
 cL
@@ -41318,7 +41836,7 @@ BL
 VS
 Ih
 MS
-lx
+MS
 Rg
 SP
 cL
@@ -41575,7 +42093,7 @@ Am
 rV
 Od
 MS
-lx
+MS
 Rg
 gn
 cL
@@ -41832,7 +42350,7 @@ Am
 yl
 ux
 MS
-lx
+MS
 Rg
 SP
 cL
@@ -42065,7 +42583,7 @@ HG
 VA
 MQ
 wu
-vs
+MX
 gq
 yu
 uj
@@ -42077,7 +42595,7 @@ zU
 uj
 CJ
 gq
-MQ
+uB
 wu
 vs
 Am
@@ -42089,7 +42607,7 @@ Am
 Ej
 zS
 MS
-lx
+MS
 Rg
 SP
 cL
@@ -42346,7 +42864,7 @@ Nn
 rV
 zS
 MS
-lx
+MS
 Rg
 SP
 cL
@@ -42603,7 +43121,7 @@ MS
 MS
 MS
 MS
-lx
+MS
 Rg
 SP
 SP
@@ -42825,9 +43343,9 @@ qO
 qO
 tz
 HI
+HI
 mK
-mK
-mK
+Kk
 mK
 mK
 HI
@@ -42855,7 +43373,7 @@ LQ
 Ya
 rO
 MS
-lx
+MS
 mK
 mK
 mK
@@ -43082,7 +43600,7 @@ qO
 qO
 tz
 HI
-mK
+HI
 mK
 mK
 mK
@@ -43339,7 +43857,7 @@ HI
 HI
 HX
 HI
-mK
+HI
 mK
 mK
 mK
@@ -43596,7 +44114,7 @@ HI
 Zf
 MF
 HI
-lX
+HI
 HI
 mK
 mK
@@ -43852,9 +44370,9 @@ qb
 HI
 zK
 Bl
-HI
+zo
 dn
-HI
+lX
 mK
 mK
 vW
@@ -44109,7 +44627,7 @@ qO
 YD
 rg
 ot
-na
+HI
 ss
 HI
 YR
@@ -44140,7 +44658,7 @@ MS
 Ge
 lh
 MS
-lx
+MS
 mK
 mK
 mK
@@ -44398,15 +44916,15 @@ MS
 ta
 MS
 MS
-lx
-lx
 MS
 MS
 MS
 MS
 MS
 MS
-lx
+MS
+MS
+MS
 cx
 cx
 cL
@@ -44649,7 +45167,7 @@ kT
 zt
 MQ
 wu
-Sc
+Uj
 pB
 CF
 GZ
@@ -44663,7 +45181,7 @@ Zi
 EL
 zS
 MS
-lx
+MS
 cx
 cx
 SP
@@ -44913,7 +45431,7 @@ Ou
 kR
 FX
 Ej
-rV
+fD
 VH
 Si
 Si
@@ -46674,7 +47192,7 @@ BQ
 Ee
 lx
 HI
-LL
+VZ
 tT
 HI
 KS
@@ -46978,7 +47496,7 @@ Xg
 ph
 dQ
 XN
-NU
+na
 mt
 hN
 cL
@@ -47491,7 +48009,7 @@ Pu
 RQ
 in
 dQ
-lx
+dQ
 cx
 cx
 cx
@@ -47748,7 +48266,7 @@ Fg
 KI
 dQ
 dQ
-lx
+dQ
 cx
 cx
 cx
@@ -47971,7 +48489,7 @@ KS
 Zs
 Pf
 hJ
-hJ
+dW
 FC
 LG
 Ea
@@ -49501,17 +50019,17 @@ cL
 lx
 HW
 Nh
-lx
-HI
-PX
-PO
-Oj
-Oj
-Oj
-Oj
-Fl
+Oa
+Oa
+Oa
+Ci
+Oa
+Oa
+Oa
+Oa
+SR
 xu
-Fl
+Bj
 xf
 xf
 xf
@@ -49758,14 +50276,14 @@ cL
 lx
 lx
 lx
-lx
-HI
+Oa
+mH
 NJ
-LL
-Oj
+Az
+Fo
 FO
 en
-Oj
+CB
 Ma
 eS
 RK
@@ -50014,18 +50532,18 @@ cL
 cL
 cL
 cL
-cL
 lx
-HI
-HI
-LL
+Oa
+bo
+hf
+js
 Xx
 pH
-EC
+qo
 Oa
 Ct
-dW
-yB
+Fy
+ls
 xf
 fv
 xf
@@ -50271,16 +50789,16 @@ cL
 cL
 cL
 cL
-cL
 lx
-lx
-HI
-VZ
-Oj
+Oa
+iV
+FK
+Az
+YJ
 jX
-ND
+EC
 JL
-oD
+Ct
 Fy
 Dt
 xf
@@ -50529,20 +51047,20 @@ cL
 cL
 cL
 cL
-cL
-lx
-HI
-HI
-Oj
+Oa
+Es
+ed
+Az
+Qf
 qe
 nk
 JL
-Fy
+sr
 Qi
 hI
 xf
 Ve
-ub
+vg
 xf
 xf
 xf
@@ -50786,19 +51304,19 @@ cL
 cL
 cL
 cL
-cL
-lx
-lx
-lx
-Oj
-Oj
-Oj
-Oj
-gS
-gS
-gS
+Oa
+Oa
+GL
+Oa
+Oa
+oi
+dj
+Oa
+sv
+le
+Vw
 xf
-ag
+tl
 xf
 xf
 mK
@@ -51046,17 +51564,17 @@ cL
 cL
 cL
 cL
-cL
-lx
-lx
-lx
-lx
-mK
+oD
+Oa
+GL
+GL
+Oa
+tg
 le
-mK
-xf
-xf
-xf
+yB
+Hd
+Ve
+ub
 xf
 mK
 mK
@@ -51303,18 +51821,18 @@ cL
 cL
 cL
 cL
-cL
-cL
-cL
-cL
-Cf
-jv
-mK
-mK
-mK
-mK
-mK
-mK
+oD
+oD
+oD
+oD
+Oj
+XO
+Xe
+yB
+xf
+ag
+xf
+xf
 mK
 mK
 mK
@@ -51563,15 +52081,15 @@ cL
 cL
 cL
 cL
-cL
-Cf
-jv
-mK
-mK
-mK
-mK
-mK
-mK
+EO
+Oj
+ve
+fs
+VX
+xf
+xf
+xf
+xf
 mK
 mK
 mK
@@ -51820,12 +52338,12 @@ cL
 cL
 cL
 cL
-cL
-Cf
-jv
-mK
-mK
-mK
+gw
+yj
+PX
+fs
+RK
+Oj
 mK
 mK
 mK
@@ -52077,12 +52595,12 @@ cL
 cL
 cL
 cL
-cL
-Cf
-xg
-mK
-mK
-mK
+EO
+Oj
+ND
+nW
+dB
+Oj
 mK
 mK
 mK
@@ -52334,12 +52852,12 @@ cL
 cL
 cL
 cL
-cL
-Cf
-Cf
-tg
-mK
-mK
+JK
+Oj
+Oj
+gS
+gS
+Oj
 mK
 mK
 mK
@@ -52591,8 +53109,8 @@ cL
 cL
 cL
 cL
-cL
-cL
+oD
+oD
 Cf
 jv
 mK

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -3432,10 +3432,6 @@
 	},
 /turf/open/floor/durasteel/techfloor,
 /area/ai_monitored/turret_protected/ai)
-"oD" = (
-/obj/structure/lattice,
-/turf/open/openspace/airless,
-/area/space)
 "oE" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -8214,7 +8210,6 @@
 /turf/open/floor/bronze,
 /area/ai_monitored/turret_protected/ai)
 "JK" = (
-/obj/structure/lattice,
 /obj/structure/lattice,
 /turf/open/openspace/airless,
 /area/space)
@@ -51550,7 +51545,7 @@ cL
 cL
 cL
 cL
-oD
+JK
 Oa
 GL
 GL
@@ -51807,10 +51802,10 @@ cL
 cL
 cL
 cL
-oD
-oD
-oD
-oD
+JK
+JK
+JK
+JK
 Oj
 XO
 Xe
@@ -53095,8 +53090,8 @@ cL
 cL
 cL
 cL
-oD
-oD
+JK
+JK
 Cf
 jv
 mK

--- a/_maps/map_files/Atlas/job_changes.dm
+++ b/_maps/map_files/Atlas/job_changes.dm
@@ -65,4 +65,10 @@ MAP_REMOVE_JOB(brig_phys)
     total_positions = 1
     spawn_positions = 1
 
+/datum/job/chemist/New()
+    ..()
+    MAP_JOB_CHECK
+    total_positions = 1
+    spawn_positions = 1
+
 #undef JOB_MODIFICATION_MAP_NAME


### PR DESCRIPTION
## About The Pull Request
przeklejam co mniej wiecej zmienilem z mojego brudnopisu

- shutter okna na kosmos
- kable ogarniete
- zlew + wiaderko + szprej u woźnego
- basen engi usuniety
- temp xeno 4 zagrody
- dodaje ore silo xD
- escape pod dodany
![image](https://github.com/aq33/NSV13/assets/48154165/bb308a79-d18d-4ca7-a8e0-b1348737b4df)
- z drugiego pokladu w kosmosie widac co jest na dole
- map errory posprzatane
- aktywne turfy startowe posprzatane
- złe area ogarniete
- plakaty
- holopady
- wózki w med
- solare ogarniete
- pododawane światła
- lethal injection do brig
- rd dostaje swój exosuit
- 1 chemik
- dodaje 2 tray do hydro
- service dostaje dostęp do swojego protolathe
- inne drobne zmiany


## Changelog
:cl:
tweak: [atlas] poprawki
/:cl:
