### PR TITLE
poprawki mapowe do trawnika

### DIFF
--- a/_maps/map_files/Serendipity/Serendipity1.dmm
+++ b/_maps/map_files/Serendipity/Serendipity1.dmm
@@ -193,7 +193,7 @@
 /area/crew_quarters/kitchen)
 "az" = (
 /obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "aA" = (
 /turf/closed/wall/r_wall/ship,
@@ -506,7 +506,7 @@
 	c_tag = "Vault South";
 	dir = 4
 	},
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "bE" = (
 /obj/effect/landmark/patrol_node{
@@ -919,7 +919,7 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/science/lab)
 "cU" = (
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "cW" = (
 /obj/structure/cable{
@@ -1379,7 +1379,7 @@
 	name = "Central Command Ferry Dock";
 	width = 5
 	},
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "eO" = (
 /obj/structure/cable{
@@ -1581,7 +1581,7 @@
 /area/crew_quarters/heads/cmo)
 "fo" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space)
 "fp" = (
 /obj/machinery/atmospherics/pipe/multiz/layer2,
@@ -1860,7 +1860,7 @@
 /area/science/xenobiology)
 "go" = (
 /obj/effect/landmark/asteroid_spawn,
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "gp" = (
 /obj/machinery/porta_turret/ai,
@@ -4463,7 +4463,7 @@
 /area/science/xenobiology)
 "oJ" = (
 /obj/structure/hull_plate,
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "oM" = (
 /obj/structure/cable{
@@ -4734,7 +4734,7 @@
 /area/medical/genetics)
 "pC" = (
 /obj/effect/landmark/carpspawn,
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space)
 "pD" = (
 /obj/structure/cable{
@@ -6793,7 +6793,7 @@
 "wt" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon,
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "wu" = (
 /obj/structure/disposalpipe/segment{
@@ -7879,7 +7879,7 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/apothecary)
 "zP" = (
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space)
 "zS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -10715,8 +10715,7 @@
 "Jb" = (
 /obj/machinery/ship_weapon/gauss_gun{
 	bound_height = 32;
-	bound_width = 32;
-	pixel_y = -96
+	bound_width = 32
 	},
 /turf/open/floor/engine/airless/light,
 /area/space/nearstation)
@@ -13235,7 +13234,7 @@
 /area/hallway/secondary/exit)
 "QW" = (
 /obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/science/xenobiology)
 "QX" = (
 /obj/machinery/computer/ship/salvage,
@@ -13603,7 +13602,7 @@
 	name = "Serendipity evac bay";
 	width = 13
 	},
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "Sp" = (
 /obj/structure/cable{
@@ -14234,7 +14233,7 @@
 /area/crew_quarters/dorms/nsv/nature_deck)
 "Ub" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/space/nearstation)
 "Uf" = (
 /obj/structure/cable{
@@ -15538,8 +15537,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment{
-	dir = 10;
-	icon_state = "pipe"
+	dir = 10
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/xo)
@@ -40877,7 +40875,7 @@ zP
 zP
 zP
 zP
-zP
+pC
 zP
 zP
 zP
@@ -50288,7 +50286,7 @@ zP
 zP
 zP
 zP
-zP
+pC
 zP
 zP
 zP
@@ -55231,7 +55229,7 @@ zP
 zP
 zP
 zP
-pC
+zP
 zP
 zP
 zP
@@ -58308,7 +58306,7 @@ zP
 zP
 zP
 zP
-pC
+zP
 zP
 zP
 zP
@@ -59074,7 +59072,7 @@ zP
 zP
 zP
 zP
-zP
+pC
 zP
 zP
 zP
@@ -59306,7 +59304,7 @@ zP
 zP
 zP
 zP
-zP
+pC
 zP
 zP
 zP

--- a/_maps/map_files/Serendipity/Serendipity1.dmm
+++ b/_maps/map_files/Serendipity/Serendipity1.dmm
@@ -269,16 +269,21 @@
 /turf/open/floor/grass,
 /area/chapel)
 "aO" = (
-/obj/structure/closet/radiation{
-	anchored = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/security)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/grass,
+/area/crew_quarters/dorms/nsv/nature_deck)
 "aQ" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen{
 	anchored = 1
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -359,6 +364,8 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/techmaint,
 /area/hallway/secondary/exit)
 "bd" = (
@@ -641,6 +648,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/latejoin,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/cryopods)
 "bY" = (
@@ -724,12 +734,11 @@
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/bridge/meeting_room/council)
 "cn" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/item/storage/bag/plants,
+/obj/item/plant_analyzer,
 /turf/open/floor/grass,
-/area/crew_quarters/dorms/nsv/nature_deck)
+/area/hydroponics)
 "co" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -752,11 +761,10 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "cv" = (
-/obj/structure/closet/emcloset{
-	anchored = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/rdserver,
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "cw" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -775,6 +783,9 @@
 /area/security/brig)
 "cy" = (
 /obj/machinery/suit_storage_unit/cmo,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
 "cA" = (
@@ -839,14 +850,16 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/hallway/secondary/exit)
 "cG" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/tiled/light,
 /area/science/server)
 "cJ" = (
@@ -995,6 +1008,14 @@
 	},
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/nsv/trauma)
+"dh" = (
+/obj/structure/table,
+/obj/item/paper/pamphlet/gateway,
+/obj/item/paper/pamphlet/gateway,
+/obj/item/paper/pamphlet/gateway,
+/obj/item/paper/pamphlet/gateway,
+/turf/open/floor/plasteel/tiled/light,
+/area/gateway)
 "di" = (
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 8
@@ -1028,6 +1049,9 @@
 	},
 /turf/open/floor/engine/light,
 /area/science/robotics)
+"dm" = (
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/crew_quarters/dorms)
 "do" = (
 /turf/closed/wall/ship,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -1231,6 +1255,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"dY" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/costume,
+/obj/effect/spawner/lootdrop/costume,
+/obj/item/relic,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "ea" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
@@ -1244,6 +1275,10 @@
 /obj/machinery/autoinject_printer,
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/chemistry)
+"ec" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "ef" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -1264,6 +1299,7 @@
 /turf/open/floor/grass,
 /area/crew_quarters/dorms/nsv/nature_deck)
 "eh" = (
+/obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1302,6 +1338,10 @@
 "eo" = (
 /turf/closed/wall/r_wall/ship,
 /area/security/main)
+"er" = (
+/obj/structure/closet/secure_closet/exile,
+/turf/open/floor/plasteel/tiled/light,
+/area/gateway)
 "ev" = (
 /obj/effect/turf_decal/tile/ship/blue{
 	dir = 1
@@ -1357,7 +1397,11 @@
 /turf/open/floor/grass,
 /area/crew_quarters/dorms/nsv/nature_deck)
 "eH" = (
-/turf/open/floor/circuit,
+/obj/machinery/rnd/server,
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/science/server)
 "eL" = (
 /obj/structure/cable{
@@ -1369,7 +1413,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/obj/machinery/hydroponics/soil,
 /turf/open/floor/grass,
 /area/hydroponics)
 "eN" = (
@@ -1569,6 +1612,13 @@
 /obj/structure/chair/fancy/bench/pew/right,
 /turf/open/floor/grass,
 /area/chapel)
+"fm" = (
+/obj/effect/turf_decal/box/corners,
+/obj/machinery/gateway{
+	dir = 6
+	},
+/turf/open/floor/monotile/dark,
+/area/gateway)
 "fn" = (
 /obj/machinery/modular_computer/console/preset/command,
 /obj/machinery/requests_console{
@@ -1762,14 +1812,19 @@
 /area/medical/medbay/lobby)
 "fY" = (
 /obj/machinery/portable_atmospherics/scrubber,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "fZ" = (
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/airlock/ship/maintenance,
-/turf/open/floor/noslip/white,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "ga" = (
 /obj/machinery/requests_console{
@@ -1858,6 +1913,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/tiled/light,
 /area/science/xenobiology)
 "go" = (
@@ -1886,9 +1944,16 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/ship/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Gateway"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tiled/light,
+/area/gateway)
 "gv" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -1921,20 +1986,21 @@
 /turf/closed/wall/ship,
 /area/ai_monitored/nuke_storage)
 "gA" = (
-/obj/machinery/door/airlock/ship/station/research/glass{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+/obj/effect/turf_decal/tile/ship/purple{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/science/server)
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/tiled/light,
+/area/gateway)
 "gB" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -1952,21 +2018,14 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/west,
-/obj/machinery/button/flasher{
-	id = "isolation";
-	name = "Left Cell Flasher";
-	pixel_x = -9;
-	pixel_y = -23
+/obj/machinery/computer/prisoner/gulag_teleporter_computer{
+	dir = 4
 	},
-/obj/machinery/button/flasher{
-	id = "isolation2";
-	name = "Right Cell Flasher";
-	pixel_x = 3;
-	pixel_y = -23
+/obj/item/storage/box/prisoner{
+	pixel_x = -7;
+	pixel_y = 8
 	},
-/obj/structure/closet/secure_closet/brig{
-	id = "pw_1"
-	},
+/obj/item/paper/guides/jobs/security/labor_camp,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
 "gD" = (
@@ -2116,6 +2175,16 @@
 	},
 /turf/open/floor/engine/light,
 /area/science/robotics)
+"gZ" = (
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/tiled/light,
+/area/gateway)
 "hc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2124,11 +2193,8 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/nsv/trauma)
 "hd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/closed/wall/ship,
-/area/maintenance/department/crew_quarters/dorms)
+/area/gateway)
 "he" = (
 /obj/structure/hull_plate,
 /obj/effect/spawner/lootdrop/crate_spawner,
@@ -2286,6 +2352,15 @@
 	},
 /turf/open/floor/engine,
 /area/science/robotics)
+"hz" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/machinery/gateway{
+	dir = 9
+	},
+/turf/open/floor/monotile/dark,
+/area/gateway)
 "hB" = (
 /obj/machinery/door/window{
 	req_one_access_txt = "25;28"
@@ -2900,6 +2975,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/carpet/red,
 /area/security/warden)
 "jv" = (
@@ -2938,13 +3016,10 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/science/lab)
 "jx" = (
-/obj/structure/fence,
 /obj/machinery/camera/autoname{
 	dir = 6
 	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/vending/hydronutrients,
 /turf/open/floor/grass,
 /area/hydroponics)
 "jy" = (
@@ -3189,12 +3264,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
 "ko" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/item/paper/fluff/gateway,
+/obj/structure/table,
+/turf/open/floor/plasteel/tiled/light,
+/area/gateway)
 "kq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3241,7 +3314,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/hydroponics/soil,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/hydroponics)
 "kD" = (
@@ -3298,6 +3371,16 @@
 	},
 /turf/open/floor/grass,
 /area/crew_quarters/dorms/nsv/nature_deck)
+"kL" = (
+/obj/machinery/door/airlock/ship/maintenance,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plasteel/tiled/light,
+/area/maintenance/department/crew_quarters/dorms)
 "kP" = (
 /obj/structure/cable{
 	icon_state = "2-5"
@@ -3660,9 +3743,20 @@
 /turf/open/floor/engine,
 /area/science/robotics)
 "lM" = (
-/obj/machinery/rnd/server,
-/turf/open/floor/circuit,
-/area/science/server)
+/obj/structure/closet/secure_closet/chemical{
+	anchored = 1
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/tiled/light,
+/area/medical/chemistry)
 "lO" = (
 /obj/structure/closet{
 	anchored = 1
@@ -3670,8 +3764,12 @@
 /turf/open/floor/wood,
 /area/crew_quarters/cryopods)
 "lP" = (
-/turf/open/floor/plating,
-/area/maintenance/department/security)
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/grass,
+/area/crew_quarters/dorms/nsv/nature_deck)
 "lR" = (
 /obj/machinery/light/floor,
 /obj/structure/cable{
@@ -3754,8 +3852,9 @@
 /turf/open/floor/grass,
 /area/crew_quarters/dorms/nsv/nature_deck)
 "mb" = (
-/obj/structure/window/plasma/reinforced/spawner/east,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/light/floor,
+/turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "me" = (
 /obj/structure/curtain/obscuring/grey,
@@ -3805,7 +3904,7 @@
 /turf/open/floor/grass,
 /area/crew_quarters/dorms/nsv/nature_deck)
 "mm" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/cryopods)
 "ms" = (
@@ -3819,6 +3918,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/flora/tree/jungle/small,
 /turf/open/floor/grass,
 /area/crew_quarters/dorms/nsv/nature_deck)
 "mt" = (
@@ -3903,9 +4003,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -3957,6 +4054,9 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/structure/closet/secure_closet/brig{
+	id = "pw_1"
+	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
 "mN" = (
@@ -4112,11 +4212,10 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/hallway/secondary/exit)
 "nl" = (
-/obj/structure/closet/crate,
-/obj/item/relic,
-/obj/effect/spawner/lootdrop/costume,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/circuit/telecomms/server,
+/area/science/server)
 "no" = (
 /obj/effect/turf_decal/tile/ship/blue{
 	dir = 1
@@ -4187,12 +4286,9 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/bridge/cic)
 "nA" = (
-/obj/machinery/door/window/eastleft{
-	req_one_access_txt = "55"
-	},
-/obj/structure/window/plasma/reinforced/spawner/north,
-/turf/open/floor/engine/light,
-/area/science/xenobiology)
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
+/turf/open/floor/grass,
+/area/crew_quarters/dorms/nsv/nature_deck)
 "nB" = (
 /obj/machinery/rnd/experimentor,
 /obj/machinery/door/window/northright,
@@ -4224,6 +4320,9 @@
 /obj/structure/sink/kitchen{
 	dir = 4;
 	pixel_x = -12
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
@@ -4447,7 +4546,16 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "oD" = (
-/turf/closed/wall/r_wall/ship,
+/obj/machinery/door/airlock/ship/hatch{
+	name = "Gateway"
+	},
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "oI" = (
 /obj/structure/reagent_dispensers/watertank{
@@ -4471,7 +4579,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/hydroponics)
 "oN" = (
@@ -4491,10 +4598,14 @@
 /turf/open/floor/grass,
 /area/crew_quarters/dorms/nsv/nature_deck)
 "oS" = (
-/obj/machinery/light/floor,
-/obj/structure/frame/machine,
-/turf/open/floor/circuit,
-/area/science/server)
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/machinery/gateway{
+	dir = 5
+	},
+/turf/open/floor/monotile/dark,
+/area/gateway)
 "oU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4507,6 +4618,9 @@
 /area/medical/genetics/cloning)
 "oV" = (
 /obj/machinery/replicator,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
 "pa" = (
@@ -4595,6 +4709,20 @@
 	},
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/medbay/lobby)
+"pi" = (
+/obj/structure/closet/secure_closet/medical1{
+	anchored = 1
+	},
+/obj/item/stack/ducts/fifty,
+/obj/item/construction/plumbing,
+/obj/item/clothing/glasses/science{
+	pixel_y = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/tiled/light,
+/area/medical/apothecary)
 "pj" = (
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/tile/yellow,
@@ -4769,6 +4897,7 @@
 /obj/item/flashlight,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/ears/earmuffs,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel/tech/grid,
 /area/hallway/secondary/exit)
 "pF" = (
@@ -4811,10 +4940,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/cryopods)
 "pN" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -4822,6 +4947,12 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/research_director,
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
 /turf/open/floor/plasteel/tiled/light,
 /area/science/server)
 "pP" = (
@@ -4855,6 +4986,10 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/plasteel/tiled/light,
 /area/hallway/secondary/exit)
+"pT" = (
+/obj/effect/spawner/room/fivexthree,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "pV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4903,10 +5038,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "qf" = (
-/obj/machinery/door/window/northleft{
-	req_one_access_txt = "55"
-	},
 /obj/machinery/light/floor,
+/obj/structure/window/plasma/reinforced/spawner/east,
 /turf/open/floor/engine/light,
 /area/science/xenobiology)
 "qg" = (
@@ -4919,11 +5052,10 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/science/lab)
 "qh" = (
-/obj/machinery/door/window/eastleft,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "qj" = (
 /obj/structure/cable{
@@ -4980,6 +5112,9 @@
 "qv" = (
 /obj/effect/turf_decal/tile/ship/blue{
 	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/apothecary)
@@ -5046,11 +5181,12 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "qN" = (
-/obj/structure/reagent_dispensers/fueltank{
-	anchored = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/structure/hull_plate,
+/turf/open/floor/engine/airless/light,
+/area/space/nearstation)
 "qP" = (
 /obj/structure/fireaxecabinet{
 	pixel_x = 32
@@ -5133,12 +5269,10 @@
 /area/security/prison)
 "rd" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/four,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/turf/open/floor/plasteel/tiled/light,
+/area/gateway)
 "re" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -5228,6 +5362,21 @@
 /mob/living/simple_animal/bot/secbot,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
+"rr" = (
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/machinery/computer/ship/viewscreen{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/tiled/light,
+/area/gateway)
 "rs" = (
 /obj/structure/closet/secure_closet/medical3{
 	anchored = 1
@@ -5269,7 +5418,7 @@
 "rC" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/computer/rdservercontrol{
 	dir = 1
 	},
 /turf/open/floor/plasteel/tiled/light,
@@ -5282,6 +5431,9 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/noslip/white,
 /area/crew_quarters/toilet)
 "rF" = (
@@ -5385,6 +5537,9 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/tiled/light,
 /area/bridge/cic)
 "rZ" = (
@@ -5452,6 +5607,12 @@
 	},
 /turf/open/floor/grass,
 /area/crew_quarters/dorms/nsv/nature_deck)
+"si" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "sj" = (
 /obj/effect/turf_decal/tile/ship/blue{
 	dir = 8
@@ -5697,9 +5858,6 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/medbay/lobby)
 "sW" = (
-/obj/machinery/door/window/northleft{
-	req_one_access_txt = "55"
-	},
 /turf/open/floor/engine/light,
 /area/science/xenobiology)
 "sY" = (
@@ -5907,10 +6065,14 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/hallway/secondary/exit)
 "tw" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 4;
+	external_pressure_bound = 120;
+	name = "server vent"
 	},
-/turf/open/floor/plating,
+/obj/structure/frame/machine,
+/obj/item/circuitboard/machine/rdserver,
+/turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "tx" = (
 /turf/closed/wall/ship,
@@ -6015,10 +6177,9 @@
 /area/medical/chemistry)
 "tS" = (
 /obj/structure/extinguisher_cabinet/west,
-/obj/structure/closet/secure_closet/warden{
-	anchored = 1
+/obj/machinery/computer/security/labor{
+	dir = 4
 	},
-/obj/item/sensor_device,
 /turf/open/floor/carpet/red,
 /area/security/warden)
 "tV" = (
@@ -6056,6 +6217,7 @@
 /obj/machinery/camera/autoname{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/east,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/prison)
 "uc" = (
@@ -6101,6 +6263,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
+"ug" = (
+/obj/structure/window/plasma/reinforced/spawner/east,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/tiled/light,
+/area/medical/genetics)
 "ui" = (
 /obj/structure/table/wood/fancy/green,
 /obj/machinery/dish_drive,
@@ -6207,7 +6376,6 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/apothecary)
 "uD" = (
-/obj/machinery/vending/hydroseeds,
 /turf/open/floor/grass,
 /area/hydroponics)
 "uF" = (
@@ -6286,16 +6454,16 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/floor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/techmaint,
 /area/hallway/secondary/exit)
 "vc" = (
@@ -6321,7 +6489,6 @@
 "vg" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
-/obj/structure/extinguisher_cabinet/west,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -6451,17 +6618,8 @@
 /turf/open/floor/grass,
 /area/crew_quarters/dorms/nsv/nature_deck)
 "vA" = (
-/obj/machinery/door/airlock/ship/station/research/glass{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/science/server)
+/turf/closed/wall/ship,
+/area/maintenance/department/crew_quarters/dorms)
 "vB" = (
 /obj/structure/closet/firecloset{
 	anchored = 1
@@ -6524,6 +6682,9 @@
 /area/crew_quarters/heads/captain/private)
 "vJ" = (
 /obj/machinery/vending/coffee,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/grass,
 /area/chapel)
 "vM" = (
@@ -6887,9 +7048,16 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/genetics/cloning)
 "wO" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plasteel/tiled/light,
-/area/science/server)
+/area/gateway)
 "wP" = (
 /turf/open/floor/plasteel/tiled/light,
 /area/science/xenobiology)
@@ -7037,6 +7205,12 @@
 /obj/machinery/light/floor,
 /turf/open/floor/engine/light,
 /area/ai_monitored/nuke_storage)
+"xe" = (
+/obj/machinery/gateway{
+	dir = 1
+	},
+/turf/open/floor/monotile/dark,
+/area/gateway)
 "xf" = (
 /obj/machinery/computer/security/mining,
 /obj/machinery/firealarm/directional/north,
@@ -7058,7 +7232,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/machinery/door/window/northleft{
+/obj/machinery/door/window/eastright{
 	req_one_access_txt = "55"
 	},
 /turf/open/floor/engine/light,
@@ -7295,16 +7469,17 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/bridge/cic)
 "xR" = (
-/obj/structure/hull_plate,
-/obj/structure/closet/crate/large{
-	anchored = 1;
-	desc = "A magnetized crate attached to the hull of the ship. You could use a crowbar to open it.";
-	name = "Magnetized crate"
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/spawner/lootdrop/maintenance/four,
-/obj/effect/spawner/lootdrop/maintenance/four,
-/turf/open/floor/engine/airless/light,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/tiled/light,
+/area/hallway/secondary/exit)
 "xT" = (
 /obj/machinery/computer/crew{
 	dir = 1
@@ -7668,6 +7843,9 @@
 	},
 /obj/effect/turf_decal/tile/ship/blue,
 /obj/machinery/limbgrower,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/nsv/trauma)
 "yX" = (
@@ -7718,9 +7896,15 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "zh" = (
-/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
-/area/science/server)
+/area/maintenance/department/crew_quarters/dorms)
 "zj" = (
 /obj/effect/turf_decal/tile/ship/blue,
 /obj/effect/turf_decal/tile/ship/blue{
@@ -7977,18 +8161,11 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/nsv/trauma)
 "Al" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
+/obj/machinery/airalarm/directional/south,
 /obj/machinery/shower{
-	dir = 1;
+	dir = 4;
 	name = "emergency shower"
 	},
-/obj/machinery/airalarm/directional/south,
-/obj/structure/curtain,
 /turf/open/floor/noslip/white,
 /area/crew_quarters/toilet)
 "Ao" = (
@@ -8015,9 +8192,11 @@
 /area/medical/genetics/cloning)
 "Ar" = (
 /obj/item/radio/intercom/directional/east,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/computer/card/minor/hos{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/carpet/red,
 /area/security/warden)
@@ -8136,11 +8315,13 @@
 /turf/open/floor/grass,
 /area/crew_quarters/dorms/nsv/nature_deck)
 "AN" = (
-/obj/machinery/door/window/eastright,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1;
+	external_pressure_bound = 140;
+	name = "server vent";
+	pressure_checks = 0
 	},
-/turf/open/floor/plating,
+/turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "AO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -8161,7 +8342,8 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/medbay/lobby)
 "AQ" = (
-/obj/machinery/firealarm/directional/south,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/grass,
 /area/crew_quarters/dorms/nsv/nature_deck)
 "AR" = (
@@ -8588,6 +8770,9 @@
 /obj/machinery/camera/autoname{
 	dir = 9
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/grass,
 /area/crew_quarters/dorms/nsv/nature_deck)
 "Ch" = (
@@ -8685,11 +8870,14 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
 "Ct" = (
-/obj/structure/window/plasma/reinforced/spawner/east,
-/obj/structure/window/plasma/reinforced/spawner/north,
-/mob/living/simple_animal/slime/random,
-/turf/open/floor/engine/light,
-/area/science/xenobiology)
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "Cv" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -8768,12 +8956,17 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "CG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/south,
+/obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/grass,
-/area/crew_quarters/dorms/nsv/nature_deck)
+/area/hydroponics)
 "CI" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
 /obj/structure/cable{
@@ -8912,6 +9105,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/nsv/weapons/starboard)
 "Dg" = (
@@ -8932,10 +9128,6 @@
 "Di" = (
 /turf/closed/wall/ship,
 /area/science/robotics)
-"Dj" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/grass,
-/area/hydroponics)
 "Dl" = (
 /obj/machinery/recharge_station,
 /obj/machinery/camera/autoname,
@@ -9121,6 +9313,10 @@
 	dir = 1
 	},
 /obj/effect/landmark/latejoin,
+/obj/machinery/computer/ship/viewscreen{
+	pixel_x = -32;
+	pixel_y = 1
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/cryopods)
 "DR" = (
@@ -9205,6 +9401,12 @@
 "Ee" = (
 /turf/closed/wall/ship,
 /area/medical/chemistry)
+"Ei" = (
+/obj/machinery/gateway{
+	icon_state = "offcenter"
+	},
+/turf/open/floor/monotile/dark,
+/area/gateway)
 "Ej" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -9236,6 +9438,9 @@
 /obj/item/reagent_containers/glass/bucket{
 	pixel_x = 5;
 	pixel_y = 5
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
@@ -9393,11 +9598,12 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
 "EO" = (
-/obj/machinery/light/floor,
-/obj/structure/frame/machine,
 /obj/item/radio/intercom/directional/south,
-/turf/open/floor/circuit,
-/area/science/server)
+/obj/structure/closet/firecloset{
+	anchored = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "EP" = (
 /obj/structure/bed,
 /obj/structure/window/plasma/reinforced/spawner/north,
@@ -9406,6 +9612,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/ship/green,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/virology)
 "EQ" = (
@@ -9506,8 +9715,24 @@
 /area/medical/virology)
 "Fj" = (
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/smartfridge/disks,
+/obj/machinery/smartfridge/disks{
+	pixel_x = -9
+	},
 /obj/structure/table/wood,
+/obj/item/shovel/spade{
+	pixel_x = 10;
+	pixel_y = 3
+	},
+/obj/item/hatchet{
+	pixel_x = 7
+	},
+/obj/item/cultivator{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/reagent_containers/spray/pestspray{
+	pixel_x = 10
+	},
 /turf/open/floor/grass,
 /area/hydroponics)
 "Fl" = (
@@ -9523,12 +9748,16 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/light/floor,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tiled/light,
+/area/gateway)
 "Fp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9892,6 +10121,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/newscaster/directional/east,
+/obj/item/clothing/gloves/color/purple,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/stock_parts/scanning_module/adv,
+/obj/item/stock_parts/scanning_module/adv,
+/obj/item/stock_parts/scanning_module,
+/obj/structure/table/glass/plasma,
 /turf/open/floor/plasteel/tiled/light,
 /area/science/server)
 "Gl" = (
@@ -9950,6 +10185,10 @@
 /obj/structure/displaycase/labcage,
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
+"Gx" = (
+/obj/machinery/gateway,
+/turf/open/floor/monotile/dark,
+/area/gateway)
 "Gy" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/ship/half/purple{
@@ -9967,8 +10206,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/tiled/light,
+/area/gateway)
 "GB" = (
 /obj/machinery/light/floor,
 /obj/structure/cable{
@@ -10094,6 +10340,9 @@
 "Hd" = (
 /obj/machinery/rnd/destructive_analyzer,
 /obj/effect/turf_decal/tile/ship/half/purple,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/tiled/light,
 /area/science/lab)
 "He" = (
@@ -10134,6 +10383,13 @@
 	},
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/chemistry)
+"Hj" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/grass,
+/area/hydroponics)
 "Hl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10164,6 +10420,9 @@
 /obj/structure/cable{
 	icon_state = "4-32"
 	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/security)
 "Hq" = (
@@ -10175,8 +10434,9 @@
 /turf/closed/wall/r_wall/ship,
 /area/crew_quarters/heads/captain/private)
 "Hs" = (
-/obj/structure/window/plasma/reinforced/spawner/north,
-/obj/structure/window/plasma/reinforced/spawner/west,
+/obj/machinery/door/window/northleft{
+	req_one_access_txt = "55"
+	},
 /turf/open/floor/engine/light,
 /area/science/xenobiology)
 "Ht" = (
@@ -10221,6 +10481,10 @@
 /obj/structure/sign/poster/official/no_erp{
 	pixel_y = -31
 	},
+/obj/structure/closet/secure_closet/warden{
+	anchored = 1
+	},
+/obj/item/sensor_device,
 /turf/open/floor/carpet/red,
 /area/security/warden)
 "HC" = (
@@ -10237,6 +10501,7 @@
 	dir = 4
 	},
 /obj/machinery/computer/ship/viewscreen,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/tiled/light,
 /area/science/server)
 "HD" = (
@@ -10295,8 +10560,10 @@
 	pixel_x = -32;
 	pixel_y = -6
 	},
-/mob/living/simple_animal/pet/dog/bullterrier/walter,
-/obj/structure/bed/dogbed/walter,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/carpet/red,
 /area/security/warden)
 "HM" = (
@@ -10319,10 +10586,11 @@
 /turf/open/floor/engine/light,
 /area/ai_monitored/nuke_storage)
 "HR" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/item/storage/bag/plants,
-/obj/item/plant_analyzer,
-/obj/item/radio/intercom/directional/east,
+/obj/machinery/computer/ship/viewscreen{
+	pixel_x = 32;
+	pixel_y = -6
+	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/hydroponics)
 "HT" = (
@@ -10335,6 +10603,9 @@
 /obj/item/gun/ballistic/automatic/pistol/glock,
 /obj/machinery/camera/autoname{
 	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/lockup)
@@ -10519,13 +10790,11 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/apothecary)
 "Ir" = (
-/obj/structure/fence/corner{
-	dir = 1
+/obj/structure/fence{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/south,
-/obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/north,
+/obj/machinery/door/firedoor/border_only/directional/south,
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/grass/fairy/yellow,
 /area/hydroponics)
@@ -10595,11 +10864,11 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/storage)
 "IE" = (
-/obj/structure/closet/firecloset{
-	anchored = 1
+/obj/machinery/gateway{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/turf/open/floor/monotile/dark,
+/area/gateway)
 "IG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -10681,9 +10950,20 @@
 /turf/open/floor/wood,
 /area/security/detectives_office)
 "IW" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/grass,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "pw_1"
+	},
+/turf/open/floor/carpet/ship/red_carpet,
+/area/security/brig)
 "IY" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/table/glass/plasma,
@@ -10803,8 +11083,6 @@
 /area/hallway/secondary/exit)
 "Jo" = (
 /obj/machinery/newscaster/directional/south,
-/obj/machinery/recharge_station,
-/obj/effect/landmark/start/cyborg,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
@@ -10822,10 +11100,8 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
 "Jr" = (
-/obj/structure/window/plasma/reinforced/spawner/north,
-/mob/living/simple_animal/slime,
-/turf/open/floor/engine/light,
-/area/science/xenobiology)
+/turf/closed/wall/r_wall/ship,
+/area/gateway)
 "Jt" = (
 /obj/machinery/recharge_station,
 /obj/effect/landmark/start/cyborg,
@@ -10862,6 +11138,11 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/structure/bed/dogbed/walter,
+/mob/living/simple_animal/pet/dog/bullterrier/walter,
 /turf/open/floor/carpet/red,
 /area/security/warden)
 "JC" = (
@@ -10875,17 +11156,23 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/nsv/trauma)
 "JD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 4;
-	external_pressure_bound = 120;
-	name = "server vent"
+/obj/structure/chair{
+	dir = 8
 	},
-/turf/open/floor/circuit,
-/area/science/server)
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/cryopods)
 "JE" = (
-/obj/structure/frame/machine,
-/turf/open/floor/circuit,
-/area/science/server)
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/machinery/gateway{
+	dir = 10
+	},
+/turf/open/floor/monotile/dark,
+/area/gateway)
 "JG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10981,9 +11268,9 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
 "JU" = (
-/obj/machinery/vending/wardrobe/hydro_wardrobe,
-/turf/open/floor/grass,
-/area/hydroponics)
+/obj/machinery/gulag_teleporter,
+/turf/open/floor/carpet/ship/red_carpet,
+/area/security/brig)
 "JV" = (
 /obj/machinery/door/airlock/ship/command/glass{
 	name = "Executive Officer's Office";
@@ -11001,15 +11288,25 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/xo)
 "JX" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/door/airlock/ship/station/research/glass{
+	dir = 4
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/light/floor,
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plasteel/tiled/light,
 /area/science/server)
 "JY" = (
-/obj/machinery/vending/hydronutrients,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/fence,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/grass,
 /area/hydroponics)
 "Ka" = (
@@ -11246,6 +11543,13 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/tiled/light,
 /area/science/lab)
+"KC" = (
+/obj/machinery/door/airlock/ship/maintenance,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/effect/landmark/zebra_interlock_point,
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "KE" = (
 /obj/item/storage/bag/tray,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -11385,12 +11689,11 @@
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/lockup)
 "KY" = (
-/obj/structure/window/plasma/reinforced/spawner/north,
-/obj/machinery/door/window/eastright{
-	req_one_access_txt = "55"
+/obj/machinery/gateway{
+	dir = 8
 	},
-/turf/open/floor/engine/light,
-/area/science/xenobiology)
+/turf/open/floor/monotile/dark,
+/area/gateway)
 "KZ" = (
 /turf/closed/wall/ship,
 /area/science)
@@ -11539,16 +11842,8 @@
 /area/nsv/weapons/starboard)
 "Lr" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
-/obj/structure/sign/poster/contraband/syndiemoth{
-	pixel_y = -31
-	},
-/obj/machinery/shower{
-	dir = 1;
-	name = "emergency shower"
-	},
-/obj/structure/curtain,
 /turf/open/floor/noslip/white,
 /area/crew_quarters/toilet)
 "Ls" = (
@@ -11767,8 +12062,11 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/nsv/trauma)
 "LU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
-/area/science/server)
+/area/maintenance/department/crew_quarters/dorms)
 "LV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11991,6 +12289,15 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet/ship,
 /area/shuttle/turbolift/primary)
+"MF" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/carpet/ship,
+/area/medical/morgue)
 "MG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12155,25 +12462,8 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/chemistry)
 "No" = (
-/obj/structure/table/wood,
-/obj/item/hatchet{
-	pixel_x = 7;
-	pixel_y = -4
-	},
-/obj/item/cultivator{
-	pixel_x = -4;
-	pixel_y = -9
-	},
-/obj/item/shovel/spade{
-	pixel_x = 10;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/spray/pestspray,
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/computer/ship/viewscreen{
-	pixel_x = 32;
-	pixel_y = -6
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/hydroponics)
 "Np" = (
@@ -12451,10 +12741,8 @@
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
 "Ok" = (
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/circuit,
+/obj/machinery/rnd/server,
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/science/server)
 "Ol" = (
 /obj/effect/turf_decal/tile/ship/half/purple{
@@ -12566,6 +12854,9 @@
 /obj/machinery/dna_scannernew,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/genetics/cloning)
 "OC" = (
@@ -12691,6 +12982,7 @@
 	dir = 9
 	},
 /obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/hydroponics)
 "Pb" = (
@@ -12828,9 +13120,7 @@
 /area/science/lab)
 "Px" = (
 /obj/machinery/airalarm/directional/north,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/turf/open/floor/carpet/red,
+/turf/closed/wall/r_wall/ship,
 /area/security/warden)
 "Pz" = (
 /obj/machinery/computer/ship/navigation/public{
@@ -13052,9 +13342,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/west{
-	pixel_y = -9
-	},
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
 "Qs" = (
@@ -13067,6 +13354,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/bridge/meeting_room/council)
@@ -13201,6 +13491,9 @@
 /area/bridge/cic)
 "QP" = (
 /obj/machinery/camera/autoname,
+/obj/machinery/door/window/eastleft{
+	req_one_access_txt = "55"
+	},
 /turf/open/floor/engine/light,
 /area/science/xenobiology)
 "QS" = (
@@ -13309,6 +13602,9 @@
 	},
 /obj/machinery/light/floor,
 /obj/machinery/camera/autoname,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 30
+	},
 /turf/open/floor/plasteel/tiled/light,
 /area/hallway/secondary/exit)
 "Rh" = (
@@ -13534,6 +13830,9 @@
 /area/crew_quarters/dorms/nsv/nature_deck)
 "Sc" = (
 /obj/machinery/photocopier,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/xo)
 "Sf" = (
@@ -13543,6 +13842,10 @@
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 11
+	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/noslip/white,
 /area/crew_quarters/toilet)
@@ -13642,10 +13945,11 @@
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/bridge/meeting_room/council)
 "Sw" = (
-/obj/item/circuitboard/machine/rdserver,
-/obj/structure/frame/machine,
-/turf/open/floor/circuit,
-/area/science/server)
+/obj/structure/reagent_dispensers/fueltank{
+	anchored = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/crew_quarters/dorms)
 "Sx" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -13658,11 +13962,13 @@
 /turf/closed/wall/ship,
 /area/maintenance/department/medical)
 "SA" = (
-/obj/structure/fence/corner,
 /obj/machinery/status_display/evac/east,
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
 /obj/effect/landmark/zebra_interlock_point,
+/obj/structure/fence{
+	dir = 4
+	},
 /turf/open/floor/grass,
 /area/hydroponics)
 "SB" = (
@@ -14019,9 +14325,21 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/brig_physician,
+/obj/machinery/button/flasher{
+	id = "isolation2";
+	name = "Right Cell Flasher";
+	pixel_x = 30;
+	pixel_y = -8
+	},
+/obj/machinery/button/flasher{
+	id = "isolation";
+	name = "Left Cell Flasher";
+	pixel_x = 21;
+	pixel_y = -8
+	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/security/brig)
 "Tv" = (
@@ -14406,15 +14724,15 @@
 	},
 /turf/open/floor/engine/light,
 /area/ai_monitored/nuke_storage)
+"UD" = (
+/obj/structure/hull_plate,
+/turf/closed/wall/r_wall/ship,
+/area/maintenance/department/crew_quarters/dorms)
 "UE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	external_pressure_bound = 140;
-	name = "server vent";
-	pressure_checks = 0
-	},
-/turf/open/floor/circuit,
-/area/science/server)
+/obj/structure/window/plasma/reinforced/spawner/west,
+/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
+/turf/open/floor/engine/light,
+/area/science/xenobiology)
 "UF" = (
 /obj/machinery/flasher/portable{
 	density = 0;
@@ -14458,12 +14776,8 @@
 /turf/open/floor/grass,
 /area/chapel)
 "UL" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
 /obj/item/radio/intercom/directional/south,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/tiled/light,
+/turf/closed/wall/ship,
 /area/science/server)
 "UN" = (
 /obj/machinery/light/floor,
@@ -14559,7 +14873,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/hydroponics/soil,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/hydroponics)
 "UZ" = (
@@ -14592,6 +14906,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/tiled/light,
 /area/hallway/secondary/exit)
@@ -14635,19 +14952,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/grass/fairy/yellow,
 /area/crew_quarters/dorms/nsv/nature_deck)
 "Vt" = (
 /turf/open/floor/engine,
 /area/science/robotics)
 "Vw" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/machinery/computer/rdservercontrol{
-	dir = 4
-	},
-/turf/open/floor/plasteel/tiled/light,
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
 /area/science/server)
 "VB" = (
 /obj/effect/spawner/structure/window/reinforced/ship,
@@ -14821,32 +15136,35 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/hallway/secondary/exit)
 "We" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/stock_parts/scanning_module,
-/obj/item/stock_parts/scanning_module/adv,
-/obj/item/stock_parts/scanning_module/adv,
-/obj/structure/table/glass/plasma,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/clothing/gloves/color/purple,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 8
+	},
 /turf/open/floor/plasteel/tiled/light,
 /area/science/server)
 "Wg" = (
 /turf/closed/wall/r_wall/ship,
 /area/bridge/meeting_room/council)
 "Wj" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/machinery/computer/ship/viewscreen{
-	pixel_y = -30
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/crew_quarters/cryopods)
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/tiled/light,
+/area/hallway/secondary/exit)
 "Wk" = (
 /obj/structure/railing{
 	dir = 1
@@ -15076,14 +15394,11 @@
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/bridge/meeting_room/council)
 "WW" = (
-/obj/structure/fence,
-/obj/machinery/door/firedoor/border_only/directional/east,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/vending/hydroseeds,
 /turf/open/floor/grass/fairy/yellow,
 /area/hydroponics)
 "WX" = (
-/obj/structure/fence,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/grass,
 /area/hydroponics)
 "WY" = (
@@ -15227,10 +15542,16 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/seven,
-/turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/obj/effect/turf_decal/tile/ship/purple{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/tiled/light,
+/area/gateway)
 "Xp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15319,6 +15640,9 @@
 "XD" = (
 /obj/machinery/vending/wardrobe/bar_wardrobe,
 /obj/machinery/camera/autoname,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
 "XE" = (
@@ -15382,7 +15706,7 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "XJ" = (
 /obj/structure/window/plasma/reinforced/spawner/west,
-/obj/structure/window/plasma/reinforced/spawner/north,
+/mob/living/simple_animal/slime/random,
 /turf/open/floor/engine/light,
 /area/science/xenobiology)
 "XK" = (
@@ -15433,6 +15757,9 @@
 /obj/effect/turf_decal/tile/ship/blue,
 /obj/machinery/iv_drip/saline,
 /obj/machinery/camera/autoname,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/tiled/light,
 /area/medical/storage)
 "XT" = (
@@ -15449,7 +15776,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/hydroponics/soil,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/hydroponics)
 "Ya" = (
@@ -15582,9 +15909,9 @@
 /turf/closed/wall/ship,
 /area/bridge/meeting_room/council)
 "YH" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/machinery/shower{
+	dir = 4;
+	name = "emergency shower"
 	},
 /turf/open/floor/noslip/white,
 /area/crew_quarters/toilet)
@@ -15633,6 +15960,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/hydroponics)
 "YQ" = (
@@ -15774,7 +16102,6 @@
 /area/hallway/secondary/exit)
 "Zm" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/hydroponics/constructable,
 /turf/open/floor/grass,
 /area/hydroponics)
 "Zo" = (
@@ -41839,14 +42166,9 @@ UT
 iv
 Zk
 dL
-AU
+xR
 Ax
-Te
-Te
-Te
-Te
-Te
-Te
+lX
 Te
 Te
 Te
@@ -41854,6 +42176,11 @@ Te
 Te
 Te
 rK
+Yy
+Yy
+Yy
+Yy
+Yy
 Rj
 DI
 DI
@@ -42098,12 +42425,7 @@ Zk
 dL
 ke
 Ax
-Te
-Te
-Te
-Te
-Te
-Te
+vD
 Te
 Te
 Te
@@ -42111,6 +42433,11 @@ Te
 Te
 Te
 eT
+Te
+vD
+Te
+Te
+Te
 QJ
 DI
 DI
@@ -42362,12 +42689,12 @@ Te
 Te
 Te
 Te
-xR
-Te
-Te
-vD
-Te
 eT
+dm
+dm
+dm
+dm
+dm
 tq
 tq
 tq
@@ -42619,12 +42946,12 @@ Yy
 Yy
 Yy
 Yy
-Yy
-Yy
-Yy
-Yy
-Yy
 De
+UD
+qb
+qb
+pT
+vA
 tq
 QW
 GG
@@ -42864,31 +43191,31 @@ gx
 Fl
 TI
 DD
-dM
+Wj
 Wd
 HE
 VC
-WD
+Ax
 Re
 WD
-WD
-Te
-Te
-he
-Te
-Te
-Te
-Te
-vD
-Te
-lE
-tq
-sC
+Jr
+Jr
+Jr
+Jr
+Jr
+Jr
+dm
+qb
+qb
+qb
+vA
+uw
+UE
 XJ
-Hs
+sC
 tq
-lE
-eT
+vD
+qN
 Te
 Te
 az
@@ -43128,23 +43455,23 @@ Qw
 WD
 tu
 Bs
-WD
-vD
-Te
-Te
-Te
-Te
-lX
-Te
-Te
-Te
-QJ
-tq
+Jr
+hz
+KY
+JE
+gZ
+hd
+vA
+qb
+qb
+qb
+vA
+uw
 QP
 qf
 xl
 tq
-QJ
+vD
 um
 Te
 Te
@@ -43385,21 +43712,21 @@ ZW
 WD
 hH
 WD
-WD
-oD
-oD
-oD
-oD
-Te
-Te
-Te
-Te
-Te
-tq
-tq
-FX
-Ct
-KY
+Jr
+xe
+Ei
+Gx
+wO
+hd
+vA
+qb
+qb
+qb
+vA
+uw
+sW
+iu
+iu
 tq
 tq
 Yn
@@ -43642,22 +43969,22 @@ AU
 FB
 Le
 pE
-WD
-cv
-nl
-IE
-oD
-il
-il
-il
-il
-il
-il
-lu
-iu
-iu
-iu
 Jr
+oS
+IE
+fm
+rr
+hd
+vA
+qb
+qb
+qb
+vA
+lu
+sW
+iu
+iu
+lu
 tq
 DW
 Te
@@ -43900,21 +44227,21 @@ Dd
 vb
 bc
 gu
-GA
+gA
 Fm
 GA
 Xo
-MP
-lM
-Ok
-eH
-lM
-MP
+hd
+vA
+vA
+KC
+vA
+vA
 AD
 sW
 eX
-sW
-qf
+Hs
+AD
 tq
 tD
 Lv
@@ -44138,7 +44465,7 @@ Tx
 Tx
 xq
 Tx
-Tx
+ug
 FI
 Ut
 TM
@@ -44156,22 +44483,22 @@ Qw
 qx
 gs
 Oa
-WD
-qN
+Jr
+dh
 ko
-qb
+er
 rd
-MP
-JE
-LU
-LU
-JE
-MP
+oD
+fZ
+qb
+qb
+Sw
+vA
 ww
-nA
+FX
 hL
 FU
-hL
+ww
 tq
 OV
 Te
@@ -44413,17 +44740,17 @@ SJ
 Gs
 Gs
 Gs
-Gs
-Gs
-Gs
-fZ
 hd
-MP
-oS
+hd
+hd
+hd
+hd
+vA
 LU
-zh
+qb
+qb
 EO
-MP
+vA
 oI
 Ol
 vn
@@ -44675,12 +45002,12 @@ DQ
 vP
 YH
 Al
-MP
-Sw
+vA
 LU
-LU
-Sw
-MP
+qb
+ec
+Ct
+vA
 SV
 wP
 ff
@@ -44932,12 +45259,12 @@ Kf
 wF
 Vp
 Lr
-MP
-JD
-eH
-eH
-UE
-MP
+kL
+zh
+si
+qb
+dY
+vA
 jB
 wP
 qD
@@ -45185,15 +45512,15 @@ mm
 zw
 Kf
 zA
-Wj
+zA
 vP
 Sf
 rE
-MP
-vA
-MP
-MP
-gA
+il
+il
+il
+il
+il
 MP
 FO
 iO
@@ -45446,11 +45773,11 @@ LJ
 Gs
 DK
 Wc
-MP
+il
 tw
 Ok
 eH
-tw
+cv
 MP
 gP
 aT
@@ -45703,9 +46030,9 @@ zl
 Gs
 Qf
 ql
-MP
+il
 qh
-mb
+nl
 mb
 AN
 MP
@@ -45960,9 +46287,9 @@ Ej
 Gs
 VQ
 Ki
-MP
+il
 JX
-wO
+MP
 Vw
 UL
 MP
@@ -46984,7 +47311,7 @@ mm
 Oi
 zT
 Gb
-Gb
+JD
 Gs
 Wp
 KZ
@@ -47494,7 +47821,7 @@ gO
 nr
 ro
 tp
-BF
+aO
 on
 BF
 BF
@@ -48522,9 +48849,9 @@ gg
 oP
 MR
 Vr
-Jz
-Jz
-xJ
+lP
+lP
+eh
 AQ
 nH
 pc
@@ -48758,7 +49085,7 @@ wX
 zO
 uL
 sz
-wX
+pi
 Ee
 fq
 Mm
@@ -49027,9 +49354,9 @@ ZJ
 PO
 LW
 ZJ
-cn
-eh
-CG
+WH
+WH
+JY
 CG
 mF
 gg
@@ -49285,7 +49612,7 @@ ZJ
 ZJ
 ZJ
 jx
-WH
+cn
 WW
 Ir
 ii
@@ -49537,12 +49864,12 @@ WJ
 xD
 ea
 Ee
-lP
+gE
 bn
 yO
 SS
-Dj
-JY
+uD
+uD
 uD
 cR
 bs
@@ -50048,15 +50375,15 @@ Ee
 Xv
 FP
 gX
-FP
+lM
 Np
 Ee
 ot
 Pb
 yO
 sy
-IW
-aq
+uD
+uD
 kC
 cR
 Jh
@@ -50312,7 +50639,7 @@ ot
 qe
 yO
 Fj
-IW
+uD
 Zm
 eL
 aC
@@ -51074,7 +51401,7 @@ ev
 ev
 gi
 sZ
-sZ
+MF
 Om
 sZ
 sZ
@@ -51084,8 +51411,8 @@ La
 Ev
 yO
 No
-HR
-JU
+uD
+aq
 cR
 SP
 li
@@ -51340,11 +51667,11 @@ VE
 CL
 Ho
 yO
-yO
-yO
+HR
 WX
+Hj
 SA
-fa
+nA
 Hf
 Xg
 xV
@@ -51596,8 +51923,8 @@ kt
 tS
 CL
 Rb
-aO
-gE
+jI
+jI
 jI
 jI
 jI
@@ -52359,7 +52686,7 @@ Cs
 yL
 Kr
 gC
-VE
+JU
 VE
 VE
 ZQ
@@ -53390,7 +53717,7 @@ vg
 Gv
 le
 oB
-ts
+IW
 jL
 rp
 eo

--- a/_maps/map_files/Serendipity/Serendipity1.dmm
+++ b/_maps/map_files/Serendipity/Serendipity1.dmm
@@ -12130,7 +12130,6 @@
 /area/crew_quarters/heads/xo)
 "Mh" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
 /turf/open/openspace/airless,
 /area/space/nearstation)
 "Mi" = (

--- a/_maps/map_files/Serendipity/Serendipity1.dmm
+++ b/_maps/map_files/Serendipity/Serendipity1.dmm
@@ -12128,10 +12128,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/xo)
-"Mh" = (
-/obj/structure/lattice/catwalk,
-/turf/open/openspace/airless,
-/area/space/nearstation)
 "Mi" = (
 /obj/machinery/stasis,
 /obj/effect/turf_decal/tile/ship/blue{
@@ -13489,10 +13485,8 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/bridge/cic)
 "QP" = (
+/obj/machinery/light/floor,
 /obj/machinery/camera/autoname,
-/obj/machinery/door/window/eastleft{
-	req_one_access_txt = "55"
-	},
 /turf/open/floor/engine/light,
 /area/science/xenobiology)
 "QS" = (
@@ -13705,6 +13699,7 @@
 /obj/machinery/computer/ship/viewscreen{
 	pixel_y = -30
 	},
+/obj/item/reagent_containers/syringe/lethal/execution,
 /turf/open/floor/carpet/ship/red_carpet,
 /area/ai_monitored/security/armory/lockup)
 "Ry" = (
@@ -14727,11 +14722,6 @@
 /obj/structure/hull_plate,
 /turf/closed/wall/r_wall/ship,
 /area/maintenance/department/crew_quarters/dorms)
-"UE" = (
-/obj/structure/window/plasma/reinforced/spawner/west,
-/obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
-/turf/open/floor/engine/light,
-/area/science/xenobiology)
 "UF" = (
 /obj/machinery/flasher/portable{
 	density = 0;
@@ -43209,7 +43199,7 @@ qb
 qb
 vA
 uw
-UE
+sC
 XJ
 sC
 tq
@@ -43466,7 +43456,7 @@ qb
 qb
 vA
 uw
-QP
+FX
 qf
 xl
 tq
@@ -44236,7 +44226,7 @@ vA
 KC
 vA
 vA
-AD
+QP
 sW
 eX
 Hs
@@ -57588,7 +57578,7 @@ BZ
 DV
 fx
 fx
-Mh
+az
 az
 zP
 zP

--- a/_maps/map_files/Serendipity/Serendipity1.dmm
+++ b/_maps/map_files/Serendipity/Serendipity1.dmm
@@ -640,6 +640,7 @@
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/wood,
 /area/crew_quarters/cryopods)
 "bY" = (
@@ -1581,8 +1582,9 @@
 /area/crew_quarters/heads/cmo)
 "fo" = (
 /obj/structure/lattice,
+/obj/structure/grille,
 /turf/open/openspace/airless,
-/area/space)
+/area/space/nearstation)
 "fp" = (
 /obj/machinery/atmospherics/pipe/multiz/layer2,
 /turf/open/floor/plating,
@@ -3377,8 +3379,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9;
-	icon_state = "pipe11-1"
+	dir = 9
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -3799,9 +3800,10 @@
 /turf/closed/wall/ship,
 /area/maintenance/department/medical)
 "mk" = (
-/obj/effect/landmark/latejoin,
-/turf/open/floor/wood,
-/area/crew_quarters/cryopods)
+/obj/structure/table/wood/fancy/green,
+/obj/item/hatchet,
+/turf/open/floor/grass,
+/area/crew_quarters/dorms/nsv/nature_deck)
 "mm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -7482,7 +7484,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/obj/effect/landmark/latejoin,
 /turf/open/floor/wood,
 /area/crew_quarters/cryopods)
 "yp" = (
@@ -7523,7 +7524,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/effect/landmark/latejoin,
 /turf/open/floor/wood,
 /area/crew_quarters/cryopods)
 "yx" = (
@@ -9120,6 +9120,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/wood,
 /area/crew_quarters/cryopods)
 "DR" = (
@@ -9626,6 +9627,7 @@
 /obj/machinery/cryopod{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/wood,
 /area/crew_quarters/cryopods)
 "FA" = (
@@ -10663,11 +10665,10 @@
 /turf/open/floor/plasteel/tiled/light,
 /area/bridge/cic)
 "IQ" = (
-/obj/machinery/recharge_station,
-/obj/effect/landmark/start/cyborg,
-/obj/effect/landmark/latejoin,
-/turf/open/floor/wood,
-/area/crew_quarters/cryopods)
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/openspace/airless,
+/area/space/nearstation)
 "IT" = (
 /obj/structure/table/glass/plasma,
 /obj/item/paper_bin,
@@ -10999,9 +11000,6 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/xo)
-"JW" = (
-/turf/closed/wall/r_wall/ship,
-/area/space/nearstation)
 "JX" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 8
@@ -11044,6 +11042,7 @@
 /obj/machinery/computer/cryopod{
 	pixel_x = -32
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/wood,
 /area/crew_quarters/cryopods)
 "Kf" = (
@@ -11832,12 +11831,10 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/xo)
 "Mh" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/landmark/start/assistant,
-/obj/effect/landmark/latejoin,
-/turf/open/floor/wood,
-/area/crew_quarters/cryopods)
+/obj/structure/lattice/catwalk,
+/obj/structure/lattice/catwalk,
+/turf/open/openspace/airless,
+/area/space/nearstation)
 "Mi" = (
 /obj/machinery/stasis,
 /obj/effect/turf_decal/tile/ship/blue{
@@ -14848,7 +14845,6 @@
 	pixel_y = -30
 	},
 /obj/effect/landmark/start/assistant,
-/obj/effect/landmark/latejoin,
 /turf/open/floor/wood,
 /area/crew_quarters/cryopods)
 "Wk" = (
@@ -44931,8 +44927,8 @@ Gu
 Tc
 yw
 yo
-mk
-mk
+Kf
+Kf
 wF
 Vp
 Lr
@@ -45186,9 +45182,9 @@ kG
 SB
 Fe
 mm
-IQ
-mk
-Mh
+zw
+Kf
+zA
 Wj
 vP
 Sf
@@ -46467,7 +46463,7 @@ yi
 WG
 ym
 sg
-td
+mk
 td
 Jh
 mm
@@ -55468,7 +55464,7 @@ cZ
 vi
 la
 Mk
-Et
+fx
 Et
 Hx
 aX
@@ -55725,7 +55721,7 @@ VV
 tG
 tg
 fx
-Et
+fx
 Et
 Lq
 qS
@@ -55982,7 +55978,7 @@ Wu
 fs
 IK
 fx
-JW
+fx
 RD
 Lq
 Lq
@@ -56227,8 +56223,8 @@ az
 bD
 az
 az
-az
-az
+Qn
+Qn
 fx
 fx
 FH
@@ -56239,7 +56235,7 @@ bV
 rX
 fx
 fx
-JW
+fx
 Et
 Lq
 Lq
@@ -56483,10 +56479,10 @@ zP
 zP
 zP
 zP
-zP
-zP
 az
 az
+fx
+fx
 fx
 eY
 SZ
@@ -56495,7 +56491,7 @@ bV
 yN
 QO
 fx
-az
+fx
 az
 Et
 iQ
@@ -56741,9 +56737,9 @@ zP
 zP
 zP
 zP
-zP
-zP
 az
+az
+fx
 fx
 fx
 My
@@ -56752,7 +56748,7 @@ XG
 Jl
 fx
 fx
-az
+fx
 az
 Et
 Et
@@ -56999,17 +56995,17 @@ zP
 zP
 zP
 zP
-zP
 az
-az
+fx
+fx
 fx
 gK
 gK
 gK
 gK
 fx
-az
-az
+fx
+fx
 az
 az
 az
@@ -57256,18 +57252,18 @@ zP
 zP
 zP
 zP
-zP
-zP
 az
+az
+fx
 fx
 DV
 BZ
 BZ
 DV
 fx
+fx
+Mh
 az
-zP
-zP
 zP
 zP
 zP
@@ -57512,20 +57508,20 @@ zP
 zP
 zP
 zP
-zP
-zP
+IQ
 zP
 az
+fx
 fx
 gK
 gK
 gK
 gK
 fx
+fx
 az
 zP
-zP
-zP
+IQ
 zP
 zP
 zP
@@ -57769,20 +57765,20 @@ zP
 zP
 zP
 zP
+IQ
 zP
+Ub
+fx
+az
+az
+az
+az
+az
+az
+fx
+Ub
 zP
-zP
-az
-az
-az
-az
-az
-az
-az
-az
-zP
-zP
-zP
+IQ
 zP
 zP
 zP
@@ -58026,20 +58022,20 @@ zP
 zP
 zP
 zP
+IQ
+IQ
+Ub
+Ub
 zP
 zP
 zP
-fo
 zP
 zP
 zP
-zP
-zP
-zP
-fo
-zP
-zP
-zP
+Ub
+Ub
+IQ
+IQ
 zP
 zP
 zP
@@ -58284,18 +58280,18 @@ zP
 zP
 zP
 zP
+IQ
 zP
-zP
-fo
-zP
-zP
-zP
+Ub
 zP
 zP
 zP
-fo
 zP
 zP
+zP
+Ub
+zP
+IQ
 zP
 zP
 zP
@@ -58541,8 +58537,8 @@ zP
 zP
 zP
 zP
-zP
-zP
+IQ
+IQ
 fo
 zP
 zP
@@ -58551,8 +58547,8 @@ zP
 zP
 zP
 fo
-zP
-zP
+IQ
+IQ
 zP
 zP
 zP
@@ -59058,12 +59054,12 @@ zP
 zP
 zP
 fo
-zP
-zP
-zP
-zP
-zP
-zP
+IQ
+IQ
+IQ
+IQ
+IQ
+IQ
 fo
 zP
 zP
@@ -59314,14 +59310,14 @@ zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
@@ -59571,14 +59567,14 @@ zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
@@ -59828,14 +59824,14 @@ zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
@@ -60085,14 +60081,14 @@ zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
@@ -60342,14 +60338,14 @@ zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
@@ -60599,14 +60595,14 @@ zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
@@ -60856,14 +60852,14 @@ zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
@@ -61113,14 +61109,14 @@ zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
@@ -61370,14 +61366,14 @@ zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
@@ -61627,14 +61623,14 @@ zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP
 zP
 zP
 zP
-fo
+Ub
 zP
 zP
 zP

--- a/_maps/map_files/Serendipity/Serendipity2.dmm
+++ b/_maps/map_files/Serendipity/Serendipity2.dmm
@@ -745,6 +745,9 @@
 /obj/structure/closet/secure_closet/engineering_personal{
 	anchored = 1
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/monotile/steel,
 /area/engine/storage_shared)
 "dR" = (
@@ -1067,6 +1070,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/engine/atmos)
@@ -1657,6 +1663,9 @@
 	dir = 4
 	},
 /obj/machinery/light/small,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "hv" = (
@@ -1898,6 +1907,9 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/structure/sign/ship/pods/east{
+	pixel_x = 32
+	},
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/hallway/nsv/deck1/hallway)
 "io" = (
@@ -2024,6 +2036,9 @@
 "iR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/hallway/nsv/deck1/hallway)
@@ -2308,8 +2323,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 10;
-	icon_state = "pipe"
+	dir = 10
 	},
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/cable{
@@ -2820,9 +2834,6 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/engine,
@@ -2974,9 +2985,6 @@
 	},
 /area/engine/engine_room)
 "nS" = (
-/obj/structure/sign/poster/official/moth5{
-	pixel_y = -31
-	},
 /obj/machinery/photocopier,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -3676,14 +3684,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/structure/sign/poster/official/moth4{
-	pixel_x = -28
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/light/floor,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
@@ -3928,7 +3936,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer2{
 	dir = 4
 	},
@@ -4055,6 +4062,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/atmos)
+"sO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/central)
 "sP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4239,6 +4255,9 @@
 	req_one_access_txt = "31;48"
 	},
 /obj/machinery/light/floor,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/monotile/light,
 /area/quartermaster)
 "tD" = (
@@ -4410,6 +4429,9 @@
 /turf/open/floor/plating,
 /area/engine/storage)
 "uq" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "ur" = (
@@ -4432,9 +4454,7 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/hallway/nsv/deck1/hallway)
 "uy" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
-	piping_layer = 3
-	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2,
 /obj/machinery/camera/autoname{
 	dir = 4
 	},
@@ -4790,9 +4810,6 @@
 /turf/open/floor/monotile/steel,
 /area/engine/armour_pump)
 "wb" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -4800,8 +4817,11 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4;
-	icon_state = "airlock_cyclelink_helper"
+	dir = 4
+	},
+/obj/machinery/door/airlock/ship/external{
+	name = "Escape Pod";
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -4883,17 +4903,15 @@
 	on = 1;
 	target_pressure = 4500
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/pipe/simple/supply/visible/layer2,
+/obj/structure/cable{
+	icon_state = "2-8";
+	tag = ""
+	},
 /turf/open/floor/engine,
 /area/engine/atmos)
 "ww" = (
@@ -4988,6 +5006,21 @@
 /obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/plasteel/tiled/light,
 /area/hallway/nsv/deck1/hallway)
+"wU" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "wW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5032,8 +5065,7 @@
 	req_one_access_txt = "69"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4;
-	icon_state = "airlock_cyclelink_helper"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -5094,6 +5126,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/quartermaster/meeting_room)
+"xv" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_room)
 "xz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/light/floor,
@@ -5314,6 +5352,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/structure/sign/ship/pods/east{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "yS" = (
@@ -5372,8 +5413,8 @@
 /area/nsv/weapons)
 "zj" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/poster/official/moth1{
-	pixel_x = -29
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
@@ -5607,8 +5648,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4;
-	icon_state = "airlock_cyclelink_helper"
+	dir = 4
 	},
 /obj/machinery/door/airlock/ship/external/glass{
 	dir = 8;
@@ -6025,10 +6065,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_room)
 "Ci" = (
-/obj/structure/sign/poster/official/moth3{
-	pixel_x = 31
-	},
 /obj/machinery/vending/wardrobe/muni_wardrobe,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/dark,
 /area/nsv/weapons/access_corridor)
 "Cj" = (
@@ -6139,6 +6179,12 @@
 "CY" = (
 /turf/closed/wall/ship,
 /area/quartermaster/lobby)
+"Da" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
+	},
+/turf/open/floor/monotile/light,
+/area/quartermaster)
 "Db" = (
 /obj/structure/extinguisher_cabinet/north,
 /turf/open/floor/monotile/light,
@@ -6211,6 +6257,9 @@
 	anchored = 1
 	},
 /obj/item/shovel,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
@@ -6428,9 +6477,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 5
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -6519,6 +6565,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light/floor,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "EK" = (
@@ -6812,6 +6861,9 @@
 	},
 /obj/item/clothing/head/helmet/decktech,
 /obj/item/clothing/head/helmet/decktech,
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/nsv/weapons)
 "FW" = (
@@ -7161,6 +7213,9 @@
 	icon_state = "2-8";
 	tag = ""
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/monotile/steel,
 /area/engine/armour_pump)
 "Hl" = (
@@ -7330,6 +7385,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
@@ -7701,8 +7759,7 @@
 /area/nsv/weapons)
 "Kf" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
-	dir = 1;
-	piping_layer = 3
+	dir = 1
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/engine,
@@ -7900,6 +7957,17 @@
 /obj/machinery/door/airlock/ship/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"KW" = (
+/obj/docking_port/stationary{
+	dwidth = 1;
+	height = 4;
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3;
+	dir = 4
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/space/basic,
+/area/space)
 "KY" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -8053,14 +8121,15 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/central)
 "LI" = (
-/obj/machinery/door/airlock/ship/external/glass{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
+	},
+/obj/machinery/door/airlock/ship/external{
+	name = "Escape Pod";
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -8107,6 +8176,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
@@ -8559,8 +8631,7 @@
 /area/nsv/hanger/mining)
 "NL" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4;
-	icon_state = "airlock_cyclelink_helper"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8655,6 +8726,9 @@
 "Oj" = (
 /obj/machinery/camera/autoname{
 	dir = 1
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel/dark,
 /area/nsv/weapons/gauss/battery/deck2)
@@ -9645,6 +9719,9 @@
 /area/nsv/weapons)
 "Sb" = (
 /obj/machinery/modular_computer/console/preset/engineering,
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
 /turf/open/floor/monotile/steel,
 /area/engine/armour_pump)
 "Sc" = (
@@ -10067,6 +10144,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/quartermaster/meeting_room)
+"TW" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/carpet/ship/beige_carpet,
+/area/hallway/nsv/deck1/hallway)
 "TX" = (
 /obj/machinery/conveyor/slow{
 	dir = 8;
@@ -10282,14 +10365,9 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "UU" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/sign/poster/official/moth7{
-	pixel_x = -29
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/engine/engine_room)
+/obj/structure/fans/tiny/invisible,
+/turf/open/space/basic,
+/area/space)
 "UX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -10556,6 +10634,9 @@
 "Wg" = (
 /obj/structure/closet/l3closet{
 	anchored = 1
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
@@ -10855,13 +10936,11 @@
 /turf/open/floor/monotile/steel,
 /area/engine/storage_shared)
 "XM" = (
-/obj/machinery/power/apc/auto_name/east{
-	start_charge = 0
-	},
 /obj/item/radio/intercom/directional/south,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plating,
 /area/engine/gravity_generator)
 "XS" = (
@@ -11195,6 +11274,21 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/plasteel/dark,
 /area/nsv/weapons)
+"Zs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "Zt" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/plasteel/dark,
@@ -38696,7 +38790,7 @@ BD
 cs
 nP
 ZT
-UU
+zj
 zj
 Rt
 gF
@@ -38724,7 +38818,7 @@ kx
 zm
 kx
 sH
-kx
+Da
 pr
 hn
 NK
@@ -42286,7 +42380,7 @@ Ks
 Ks
 dD
 Mo
-YJ
+xv
 YJ
 uH
 XW
@@ -44087,7 +44181,7 @@ dD
 Kn
 Rw
 Kn
-gi
+wU
 Lz
 yD
 yD
@@ -44374,7 +44468,7 @@ ta
 lt
 XY
 Gr
-RF
+sO
 Aj
 yc
 or
@@ -45651,7 +45745,7 @@ mq
 gp
 wd
 mp
-mp
+TW
 mp
 iv
 mp
@@ -47962,7 +48056,7 @@ AF
 kw
 cM
 lw
-WL
+Zs
 jK
 Bv
 xr
@@ -50274,9 +50368,9 @@ Sg
 Sg
 Sg
 Sg
-Sg
-Sg
-Sg
+UU
+KW
+UU
 Sg
 zG
 zG
@@ -50531,9 +50625,9 @@ Sg
 Sg
 Sg
 Sg
-Sg
-Sg
-Sg
+Ks
+Ks
+Ks
 Sg
 Sg
 Sg
@@ -50788,9 +50882,9 @@ Sg
 Sg
 Sg
 Sg
-Sg
-Sg
-Sg
+Ks
+Ks
+Ks
 Sg
 Sg
 Sg
@@ -51045,9 +51139,9 @@ dD
 dD
 dD
 dD
-dD
-dD
-dD
+Ks
+Ks
+Ks
 dD
 dD
 dD

--- a/config/config.txt
+++ b/config/config.txt
@@ -71,7 +71,7 @@ MENTOR_LEGACY_SYSTEM
 #MENTORS_MOBNAME_ONLY
 
 ## Comment this out to stop locally connected clients from being given the almost full access !localhost! admin rank
-ENABLE_LOCALHOST_RANK
+#ENABLE_LOCALHOST_RANK
 
 ## Uncomment this entry to have certain jobs require your account to be at least a certain number of days old to select. You can configure the exact age requirement for different jobs by editing
 ## the minimal_player_age variable in the files in folder /code/game/jobs/job/.. for the job you want to edit. Set minimal_player_age to 0 to disable age requirement for that job.

--- a/config/config.txt
+++ b/config/config.txt
@@ -71,7 +71,7 @@ MENTOR_LEGACY_SYSTEM
 #MENTORS_MOBNAME_ONLY
 
 ## Comment this out to stop locally connected clients from being given the almost full access !localhost! admin rank
-#ENABLE_LOCALHOST_RANK
+ENABLE_LOCALHOST_RANK
 
 ## Uncomment this entry to have certain jobs require your account to be at least a certain number of days old to select. You can configure the exact age requirement for different jobs by editing
 ## the minimal_player_age variable in the files in folder /code/game/jobs/job/.. for the job you want to edit. Set minimal_player_age to 0 to disable age requirement for that job.


### PR DESCRIPTION
## About The Pull Request

Tak samo jak w przypadku atlas, przeklejam zmiany z brudnopisu. Bylo ich o wiele mniej ponieważ robilem mniej szczegółowo

przestawia pare spawnów,
umacnia mostek
![StrongDMM_UoiBGApbEr](https://github.com/aq33/NSV13/assets/48154165/3d8fe276-4f23-4463-8e8c-5cf9d0dfba52)
wieksze zagrody i jajo w xeno
konsolka gulag
escape pod
powieksza hydroponike
troche poprawia kable
gateway
![StrongDMM_nlrgypcukC](https://github.com/aq33/NSV13/assets/48154165/27c1db3d-12e3-4a4b-9bc4-869320b6d3a2)
naprawia gravgen
plakaty
pierdoły



## Changelog
:cl:
tweak: poprawki na serendipytypy
/:cl:
