### PR TITLE
Dodaje wybuchowy implant który reaguje na eksplozje stormdrive

### DIFF
--- a/aquila/aquila.dm
+++ b/aquila/aquila.dm
@@ -53,6 +53,7 @@
 #include "code\game\objects\items\devices\scanners.dm"
 #include "code\game\objects\items\dna_injector.dm"
 #include "code\game\objects\items\flamethrower.dm"
+#include "code\game\objects\items\implants\implant_explosive.dm"
 #include "code\game\objects\items\implants\implant_security.dm"
 #include "code\game\objects\items\inducer.dm"
 #include "code\game\objects\items\manuals.dm"

--- a/aquila/code/game/objects/items/implants/implant_explosive.dm
+++ b/aquila/code/game/objects/items/implants/implant_explosive.dm
@@ -1,0 +1,46 @@
+/obj/item/implant/explosive/engineering
+	actions_types = list() // override to not let person explode it themselves
+
+/obj/item/implant/explosive/engineering/Initialize(mapload)
+	. = ..()
+	RegisterSignal(SSdcs, COMSIG_GLOB_STROMDRIVE_EXPLOSION, PROC_REF(stormdrive_went_boom))
+
+/obj/item/implant/explosive/engineering/on_mob_death()
+	return // this one doesn't explode on death
+
+/obj/item/implant/explosive/engineering/get_data()
+	var/dat = {"<b>Implant Specifications:</b><BR>
+				<b>Name:</b> Robust Corp RX-79 Engineering Punishment Implant<BR>
+				<b>Life:</b> Activates upon stormdrive explosion.<BR>
+				<b>Important Notes:</b> Explodes<BR>
+				<HR>
+				<b>Implant Details:</b><BR>
+				<b>Function:</b> Contains a compact, electrically detonated explosive that detonates upon detecting stormdrive explosion.<BR>
+				<b>Special Features:</b> Explodes<BR>
+				"}
+	return dat
+
+/obj/item/implant/explosive/engineering/proc/stormdrive_went_boom()
+	to_chat(imp_in, "<span class='userdanger'>Pozwoliłeś żeby silnik stormdrive wybuchł, przygotuj się na działania dyscyplinarne</span>")
+	addtimer(CALLBACK(src, PROC_REF(activate), "stormdrive"), 5 SECONDS)
+
+/datum/job/after_spawn(mob/living/H, mob/M)
+	. = ..()
+	if(M.real_name == "Zachary Andromalis")
+
+
+/datum/job/chief_engineer/after_spawn(mob/living/H, mob/M)
+	. = ..()
+	var/obj/item/implant/explosive/engineering/ce_fucked_up = new
+	ce_fucked_up.implant(H, null, silent = TRUE)
+
+/obj/item/implantcase/engineering
+	name = "implant case - 'engineers fucked up'"
+	desc = "A glass case containing a modified explosive implant."
+	imp_type = /obj/item/implant/explosive/engineering
+
+/obj/item/storage/box/engimp/PopulateContents()
+	var/static/items_inside = list(
+		/obj/item/implantcase/engineering = 5,
+		/obj/item/implanter = 1)
+	generate_items_inside(items_inside,src)

--- a/aquila/code/game/objects/items/implants/implant_explosive.dm
+++ b/aquila/code/game/objects/items/implants/implant_explosive.dm
@@ -27,6 +27,8 @@
 /datum/job/after_spawn(mob/living/H, mob/M)
 	. = ..()
 	if(M.real_name == "Zachary Andromalis")
+		var/obj/item/implant/explosive/engineering/zachary_fucked_up = new
+		zachary_fucked_up.implant(H, null, silent = TRUE)
 
 
 /datum/job/chief_engineer/after_spawn(mob/living/H, mob/M)

--- a/code/__DEFINES/dcs/signals/signals_global.dm
+++ b/code/__DEFINES/dcs/signals/signals_global.dm
@@ -30,3 +30,7 @@
 
 /// research has been researched
 #define COMSIG_GLOB_NEW_RESEARCH "!remote_research_changed"
+
+//aquila edit
+#define COMSIG_GLOB_STROMDRIVE_EXPLOSION "!stormdrive_boom"								//! Sent if any stormdrive explodes
+//aquila edit end

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -29,6 +29,7 @@
 	new /obj/item/computer_hardware/hard_drive/role/captain(src)
 	new /obj/item/storage/box/silver_ids(src)
 	new /obj/item/restraints/handcuffs/cable/zipties(src)
+	new /obj/item/storage/box/engimp(src) // aquila edit
 
 	// prioritized items
 	new /obj/item/card/id/departmental_budget/civ(src)

--- a/nsv13/code/modules/power/stormdrive.dm
+++ b/nsv13/code/modules/power/stormdrive.dm
@@ -1196,6 +1196,7 @@ Control Rods
 	empulse(src, 25, 50)
 	radiation_pulse(src, 10000, 1)
 	src.atmos_spawn_air("o2=750;plasma=200;nucleium=100;TEMP=5000")
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_STROMDRIVE_EXPLOSION) // AQ edit
 
 	for(var/mob/living/M in GLOB.alive_mob_list)
 		if(shares_overmap(src, M))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Kapitan teraz dostaje 5 implantów które wybuchają gdy stormdrive wybuchnie
CE i prawdziwy CE też dostają te implanty domyślnie
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
![image](https://github.com/aq33/NSV13/assets/40302913/6010b268-4902-48fb-9c54-8d0581c4b5e0)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.
-->

## Changelog
:cl:
add: Możliwość ukarania przez kapitana inżynierii za sabotaż.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
