### PR TITLE
9mm Buff

### DIFF
--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -2,16 +2,16 @@
 
 /obj/item/projectile/bullet/c9mm
 	name = "9mm bullet"
-	damage = 30
+	damage = 20
 
 /obj/item/projectile/bullet/c9mm_ap
 	name = "9mm armor-piercing bullet"
-	damage = 23
+	damage = 15
 	armour_penetration = 40
 
 /obj/item/projectile/bullet/incendiary/c9mm
 	name = "9mm incendiary bullet"
-	damage = 15
+	damage = 10
 	fire_stacks = 1
 
 // 10mm (Stechkin)

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -2,16 +2,16 @@
 
 /obj/item/projectile/bullet/c9mm
 	name = "9mm bullet"
-	damage = 20
+	damage = 30
 
 /obj/item/projectile/bullet/c9mm_ap
 	name = "9mm armor-piercing bullet"
-	damage = 15
+	damage = 23
 	armour_penetration = 40
 
 /obj/item/projectile/bullet/incendiary/c9mm
 	name = "9mm incendiary bullet"
-	damage = 10
+	damage = 15
 	fire_stacks = 1
 
 // 10mm (Stechkin)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -13,7 +13,7 @@
 	design_ids = list("basic_matter_bin", "basic_cell", "basic_scanning", "basic_capacitor", "basic_micro_laser", "micro_mani", "dest_tagger", "handlabel", "larry", "package_wrap",
 	"destructive_analyzer", "circuit_imprinter", "experimentor", "rdconsole", "design_disk", "tech_disk", "rdserver", "rdservercontrol", "mechfab", "paystand",
 	"space_heater", "beaker", "large_beaker", "bucket", "xlarge_beaker", "sec_rshot", "sec_beanbag_slug", "sec_bshot", "sec_slug", "sec_Islug", "sec_Brslug", "sec_dart", "sec_38", "sec_38b",
-	"rglass","plasteel","plastitanium","plasmaglass","plasmareinforcedglass","titaniumglass","plastitaniumglass","plumbing_rcd", "antivirus", "glasses_prescription", "light_replacer", "xenoa_labeler", "nanocarbon_glass", "durasteel", "duranium", "coffeemaker", "coffeepot", "coffee_cartridge", "syrup_bottle", "fax") //NSV13 - BLOOD FOR THE BLOOD GOD, COFFEE FOR THE NAVY!!
+	"rglass","plasteel","plastitanium","plasmaglass","plasmareinforcedglass","titaniumglass","plastitaniumglass","plumbing_rcd", "antivirus", "glasses_prescription", "light_replacer", "xenoa_labeler", "nanocarbon_glass", "durasteel", "duranium", "coffeemaker", "coffeepot", "coffee_cartridge", "syrup_bottle", "fax", "glock_lethalammo", "glock_rubberammo") //NSV13 - BLOOD FOR THE BLOOD GOD, COFFEE FOR THE NAVY!!
 
 /datum/techweb_node/mmi
 	id = "mmi"
@@ -942,7 +942,7 @@
 	display_name = "Ballistic Weaponry"
 	description = "This isn't research.. This is reverse-engineering!"
 	prereq_ids = list("weaponry")
-	design_ids = list("mag_oldsmg", "mag_oldsmg_ap", "mag_oldsmg_ic", "mag_oldsmg_rubber", "glock_lethalmag", "glock_rubbermag", "glock_apmag", "glock_incmag", "glock_lethalammo", "glock_rubberammo", "glock_apammo", "glock_incammo")
+	design_ids = list("mag_oldsmg", "mag_oldsmg_ap", "mag_oldsmg_ic", "mag_oldsmg_rubber", "glock_lethalmag", "glock_rubbermag", "glock_apmag", "glock_incmag", "glock_apammo", "glock_incammo")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -12,8 +12,8 @@
 	//NSV13 Added 3 ids for NSV13 hull materials
 	design_ids = list("basic_matter_bin", "basic_cell", "basic_scanning", "basic_capacitor", "basic_micro_laser", "micro_mani", "dest_tagger", "handlabel", "larry", "package_wrap",
 	"destructive_analyzer", "circuit_imprinter", "experimentor", "rdconsole", "design_disk", "tech_disk", "rdserver", "rdservercontrol", "mechfab", "paystand",
-	"space_heater", "beaker", "large_beaker", "bucket", "xlarge_beaker", "sec_rshot", "sec_beanbag_slug", "sec_bshot", "sec_slug", "sec_Islug", "sec_Brslug", "sec_dart", "sec_38", "sec_38b",
-	"rglass","plasteel","plastitanium","plasmaglass","plasmareinforcedglass","titaniumglass","plastitaniumglass","plumbing_rcd", "antivirus", "glasses_prescription", "light_replacer", "xenoa_labeler", "nanocarbon_glass", "durasteel", "duranium", "coffeemaker", "coffeepot", "coffee_cartridge", "syrup_bottle", "fax", "glock_lethalammo", "glock_rubberammo") //NSV13 - BLOOD FOR THE BLOOD GOD, COFFEE FOR THE NAVY!!
+	"space_heater", "beaker", "large_beaker", "bucket", "xlarge_beaker", "sec_rshot", "sec_beanbag_slug", "sec_bshot", "sec_slug", "sec_Islug", "sec_Brslug", "sec_dart", "sec_38", "sec_38b", "glock_lethalammo", "glock_rubberammo",
+	"rglass","plasteel","plastitanium","plasmaglass","plasmareinforcedglass","titaniumglass","plastitaniumglass","plumbing_rcd", "antivirus", "glasses_prescription", "light_replacer", "xenoa_labeler", "nanocarbon_glass", "durasteel", "duranium", "coffeemaker", "coffeepot", "coffee_cartridge", "syrup_bottle", "fax") //NSV13 - BLOOD FOR THE BLOOD GOD, COFFEE FOR THE NAVY!!
 
 /datum/techweb_node/mmi
 	id = "mmi"

--- a/nsv13/code/modules/jobs/security/weapons.dm
+++ b/nsv13/code/modules/jobs/security/weapons.dm
@@ -252,7 +252,7 @@
 
 /obj/item/projectile/bullet/c9mm/rubber
 	name = "Pocisk 9mm"
-	damage = 20
+	damage = 30
 	damage_type = STAMINA
 	icon = 'nsv13/icons/obj/projectiles_nsv.dmi'
 	icon_state = "pdc"


### PR DESCRIPTION
-Zwiększa obrażenia kul gumowych 9mm do 30
-Podstawowa amunicja (Gumowa, Letalna) dostępna do drukowania w protolathe sec na start (Zaawansowane typy amunicji i magazynki dalej potrzebują riserczu)

Tak to wygląda przed buffem:

https://github.com/aq33/NSV13/assets/68994323/2b706bf6-5251-4e18-8226-002fba784f18



