### PR TITLE
spowolnienie lasera

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -8,6 +8,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
 	ammo_x_offset = 1
 	shaded_charge = 1
+	fire_rate = 1 //AQ EDIT powolne wystrzały ze względu na hitscan
 
 /obj/item/gun/energy/laser/practice
 	name = "practice laser gun"
@@ -38,11 +39,12 @@
 	force = 10
 	ammo_x_offset = 3
 	selfcharge = 1
-	charge_delay = 8
+	charge_delay = 12 //AQ EDIT 8 -> 12
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun/captain)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	weapon_weight = WEAPON_LIGHT
 	investigate_flags = ADMIN_INVESTIGATE_TARGET
+	fire_rate = 0.7 //AQ EDIT nieskończona moc w skończonej formie
 
 /obj/item/gun/energy/laser/captain/scattershot
 	name = "scatter shot laser rifle"
@@ -88,6 +90,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/accelerator)
 	pin = null
 	ammo_x_offset = 3
+	fire_rate = 1 //AQ EDIT
 
 /obj/item/ammo_casing/energy/laser/accelerator
 	projectile_type = /obj/item/projectile/beam/laser/accelerator
@@ -114,6 +117,7 @@
 	pin = null
 	ammo_x_offset = 3
 	w_class = WEIGHT_CLASS_BULKY
+	fire_rate = 0.8 //AQ EDIT ditto + ignorowanie ściań i 20 strzałów
 
 ////////Laser Tag////////////////////
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Spowolniono laserki;
- normalne lasery na 1 strzał na sekunde
- x-ray laser na 0.8 na sekunde
- laser zabytkowy na 0.7 oraz zwiększono opóźnienie samoładowania na 12 z 8 

## Why It's Good For The Game
hitscan

## Changelog
:cl:
tweak: Zmieniono sybkostrzelność laserów na wolniejszy ze względu na wiązki
balance: Spowolniono samoładowanie lasera zabytkowego
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
