### PR TITLE
dogazowanie gazu pieprzowego

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -296,8 +296,8 @@
 		//check for protection
 		//actually handle the pepperspray effects
 		if(!victim.is_eyes_covered() || !victim.is_mouth_covered())
-			victim.blur_eyes(5) // 10 seconds
-			victim.blind_eyes(3) // 6 seconds
+			victim.blur_eyes(15) // 10 seconds -> 30 AQ EDIT
+			victim.blind_eyes(6) // 6 seconds -> 12 AQ EDIT
 			victim.Knockdown(3 SECONDS)
 			if(prob(5))
 				victim.emote("scream")

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -296,8 +296,8 @@
 		//check for protection
 		//actually handle the pepperspray effects
 		if(!victim.is_eyes_covered() || !victim.is_mouth_covered())
-			victim.blur_eyes(15) // 10 seconds -> 30 AQ EDIT
-			victim.blind_eyes(6) // 6 seconds -> 12 AQ EDIT
+			victim.blur_eyes(8) // 10 seconds -> 16 AQ EDIT
+			victim.blind_eyes(3) // 6 seconds
 			victim.Knockdown(3 SECONDS)
 			if(prob(5))
 				victim.emote("scream")

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -302,7 +302,7 @@
 			victim.Paralyze(3 SECONDS)
 			if(prob(5))
 				victim.emote("scream")
-			victim.confused = max(M.confused, 10) // 10 seconds -> 20 AQ EDIT ebd
+			victim.confused = max(M.confused, 10) // 10 seconds -> 20 AQ EDIT end
 			victim.add_movespeed_modifier(MOVESPEED_ID_PEPPER_SPRAY, update=TRUE, priority=100, multiplicative_slowdown=0.25, blacklisted_movetypes=(FLYING|FLOATING))
 			addtimer(CALLBACK(victim, TYPE_PROC_REF(/mob, remove_movespeed_modifier), MOVESPEED_ID_PEPPER_SPRAY), 10 SECONDS)
 		victim.update_damage_hud()

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -296,12 +296,13 @@
 		//check for protection
 		//actually handle the pepperspray effects
 		if(!victim.is_eyes_covered() || !victim.is_mouth_covered())
-			victim.blur_eyes(8) // 10 seconds -> 16 AQ EDIT
-			victim.blind_eyes(3) // 6 seconds
-			victim.Knockdown(3 SECONDS)
+			victim.blur_eyes(15) // 10 seconds -> 30 AQ EDIT start
+			victim.blind_eyes(6) // 6 seconds -> 12
+			victim.Knockdown(6 SECONDS)
+			victim.Paralyze(3 SECONDS)
 			if(prob(5))
 				victim.emote("scream")
-			victim.confused = max(M.confused, 5) // 10 seconds
+			victim.confused = max(M.confused, 10) // 10 seconds -> 20 AQ EDIT ebd
 			victim.add_movespeed_modifier(MOVESPEED_ID_PEPPER_SPRAY, update=TRUE, priority=100, multiplicative_slowdown=0.25, blacklisted_movetypes=(FLYING|FLOATING))
 			addtimer(CALLBACK(victim, TYPE_PROC_REF(/mob, remove_movespeed_modifier), MOVESPEED_ID_PEPPER_SPRAY), 10 SECONDS)
 		victim.update_damage_hud()


### PR DESCRIPTION
## About The Pull Request

gaz pieprzowy teraz powala faktycznie na chwilę, oślepia dłużej, efekt rozmycia ekranu, który jest praktycznie nieszkodliwy trwa 30 sekund oraz status confuse jest wydłużony. Teraz będziesz mieć imersje uciekania oraz zataczania się ze szklankami w oczach po gazie

## Why It's Good For The Game
Gaz pieprzowy będzie dzięki temu mniej zagracać ekwipunek
https://www.youtube.com/watch?v=Hws03KUi28k

## Changelog
:cl:
tweak: Zmieniono gaz pieprzowy z pomniejszej irytacji na bardziej dotkliwe utrudnienie
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
