### PR TITLE
ścisza PA

### DIFF
--- a/code/modules/power/singularity/particle_accelerator/particle_control.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_control.dm
@@ -119,7 +119,7 @@
 			return
 		//emit some particles
 		for(var/obj/structure/particle_accelerator/particle_emitter/PE in connected_parts)
-			playsound(src, 'aquila/sound/machines/wubb.ogg', 50) // AQ EDIT
+			playsound(src, 'aquila/sound/machines/wubb.ogg', 25) // AQ EDIT
 			PE.emit_particle(strength)
 
 /obj/machinery/particle_accelerator/control_box/proc/part_scan()


### PR DESCRIPTION
Ścisza o połowę PA, bo ktoś na to narzekał i w sumie na starej AQ też tak było.