### PR TITLE
[Atlas] Dodanie Turbiny do atmosa

### DIFF
--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -32,7 +32,7 @@
 /obj/machinery/atmospherics/components/binary/pump/layer4{
 	name = "O2 to mix"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "ae" = (
 /obj/structure/sign/poster/contraband/random{
@@ -312,7 +312,7 @@
 /obj/machinery/atmospherics/components/trinary/mixer/flipped/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "aV" = (
 /turf/template_noop,
@@ -753,7 +753,7 @@
 /obj/structure/fireaxecabinet{
 	pixel_y = 32
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "ct" = (
 /obj/structure/lattice/catwalk/over/ship,
@@ -1097,7 +1097,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "dr" = (
 /obj/effect/turf_decal/ship/techfloor/corner{
@@ -1290,7 +1290,7 @@
 /obj/machinery/atmospherics/components/binary/valve{
 	name = "Output to Space"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "dX" = (
 /obj/structure/disposalpipe/sorting/mail{
@@ -1464,7 +1464,7 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/effect/landmark/start/atmospheric_technician,
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "ew" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1526,7 +1526,7 @@
 /obj/machinery/atmospherics/components/trinary/mixer/layer4{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "eH" = (
 /obj/effect/landmark/carpspawn,
@@ -1616,7 +1616,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer2{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "eY" = (
 /turf/closed/wall/r_wall,
@@ -2094,7 +2094,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "ge" = (
 /obj/machinery/computer/security/telescreen/atc{
@@ -2174,7 +2174,7 @@
 	c_tag = "Atmos - Airlock #2";
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "go" = (
 /obj/structure/cable{
@@ -2704,7 +2704,7 @@
 	dir = 1;
 	id = "iowaturb"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "hI" = (
 /obj/effect/turf_decal/stripes/line{
@@ -2915,7 +2915,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "iv" = (
 /obj/structure/table/reinforced,
@@ -2991,7 +2991,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/tile_marquee,
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/alt,
 /area/engine/atmos)
 "iH" = (
 /obj/structure/cable{
@@ -3169,7 +3169,7 @@
 /area/quartermaster/storage)
 "je" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan,
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "jf" = (
 /obj/structure/disposalpipe/segment{
@@ -3998,7 +3998,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "li" = (
 /obj/machinery/armour_plating_nanorepair_pump/forward_starboard{
@@ -4018,11 +4018,15 @@
 /area/space/nearstation)
 "lm" = (
 /obj/machinery/igniter/incinerator_atmos,
+/obj/effect/decal/cleanable/ash,
+/obj/machinery/sparker{
+	id = "atmos_incinerator_igniter";
+	pixel_x = -19
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4;
 	filter_types = list("co2","bz","water_vapor")
 	},
-/obj/effect/decal/cleanable/ash,
 /turf/open/floor/engine/airless,
 /area/engine/atmos)
 "ln" = (
@@ -4303,7 +4307,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "lY" = (
 /obj/machinery/atmospherics/pipe/simple/cyan{
@@ -4351,7 +4355,7 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "mj" = (
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "mk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -4392,7 +4396,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "ms" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4555,7 +4559,7 @@
 	dir = 4
 	},
 /obj/machinery/computer/atmos_control/tank/oxygen_tank,
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "mX" = (
 /turf/open/floor/carpet/orange,
@@ -4568,13 +4572,13 @@
 	node2_concentration = 0.21;
 	piping_layer = 2
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "mZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "nc" = (
 /obj/effect/turf_decal/stripes/line,
@@ -4770,7 +4774,7 @@
 /area/hallway/nsv/deck2/primary)
 "nz" = (
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "nA" = (
 /obj/structure/particle_accelerator/particle_emitter/center{
@@ -4836,9 +4840,8 @@
 /area/engine/atmos)
 "nH" = (
 /obj/effect/decal/cleanable/ash/large,
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
-	dir = 4;
-	id = "turbine_in"
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
+	dir = 4
 	},
 /obj/machinery/air_sensor/atmos/incinerator_tank,
 /turf/open/floor/engine/airless,
@@ -4900,14 +4903,14 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "nN" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "nO" = (
 /obj/structure/disposalpipe/sorting/mail{
@@ -4935,7 +4938,7 @@
 	name = "Air to distro";
 	target_pressure = 2000
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "nU" = (
 /obj/structure/cable{
@@ -4961,7 +4964,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "oe" = (
 /obj/machinery/light/runway/delay5,
@@ -5093,7 +5096,7 @@
 "or" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4,
 /obj/machinery/atmospherics/pipe/manifold/purple/visible/layer2,
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "os" = (
 /obj/structure/window/reinforced{
@@ -5509,11 +5512,14 @@
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
 "pt" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 6
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "pw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -5816,6 +5822,9 @@
 "qf" = (
 /turf/closed/wall/r_wall,
 /area/science/nanite)
+"qg" = (
+/turf/open/floor/durasteel/alt,
+/area/engine/atmos)
 "qi" = (
 /obj/machinery/door/airlock/ship/maintenance,
 /obj/machinery/door/firedoor/border_only,
@@ -6155,7 +6164,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "rq" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6204,7 +6213,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "ry" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -6731,7 +6740,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "th" = (
 /obj/effect/turf_decal/tile/orange{
@@ -6767,9 +6776,6 @@
 /area/hallway/nsv/deck2/primary)
 "tm" = (
 /obj/effect/turf_decal/tile/ship/half/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -6907,7 +6913,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "tB" = (
 /obj/machinery/firealarm{
@@ -7394,7 +7400,7 @@
 /obj/machinery/atmospherics/pipe/manifold/purple/visible/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "uK" = (
 /turf/open/floor/plating{
@@ -7720,7 +7726,7 @@
 /obj/machinery/computer/atmos_control/tank/mix_tank{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "vJ" = (
 /obj/machinery/conveyor{
@@ -8132,7 +8138,7 @@
 /area/maintenance/nsv/deck2/port/fore)
 "xd" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "xe" = (
 /obj/structure/cable{
@@ -8213,7 +8219,7 @@
 	name = "Atmospherics RC";
 	pixel_y = -30
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "xr" = (
 /obj/machinery/turnstile{
@@ -8319,7 +8325,7 @@
 	output_tag = "sdmix_out";
 	sensors = list("sdmix_sensor"="Reactor                Mix                Tank")
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "xK" = (
 /obj/structure/chair/office{
@@ -8718,7 +8724,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "yV" = (
 /obj/machinery/light/small{
@@ -8990,11 +8996,22 @@
 /turf/open/floor/monotile/steel,
 /area/science)
 "zI" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 9
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/engine/atmos)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/landmark/zebra_interlock_point,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 6
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "zJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -9501,7 +9518,7 @@
 	dir = 4
 	},
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank,
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "BD" = (
 /obj/machinery/biogenerator,
@@ -9522,7 +9539,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/south,
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "BH" = (
 /obj/effect/turf_decal/tile/ship/green,
@@ -9627,7 +9644,7 @@
 /area/science/explab)
 "BU" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "BV" = (
 /obj/effect/turf_decal/ship/techfloor,
@@ -9811,7 +9828,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/tile_marquee,
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/alt,
 /area/engine/atmos)
 "Cw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -10583,7 +10600,7 @@
 	name = "Nitrogen to Air Mix";
 	target_pressure = 2000
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "Fh" = (
 /obj/structure/rack,
@@ -10740,7 +10757,7 @@
 	dir = 6
 	},
 /obj/machinery/portable_atmospherics/canister/toxins,
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "FD" = (
 /obj/machinery/button/door{
@@ -11082,7 +11099,7 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "GC" = (
 /obj/machinery/light/small{
@@ -11593,7 +11610,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "HX" = (
 /obj/structure/lattice,
@@ -11665,7 +11682,7 @@
 	target_layer = 4;
 	name = "Scrubber loop gas flow meter"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "In" = (
 /obj/effect/turf_decal/tile/ship/red,
@@ -12205,7 +12222,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "JW" = (
 /obj/effect/turf_decal/ship/techfloor{
@@ -12478,7 +12495,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "KK" = (
 /obj/effect/turf_decal/tile/purple{
@@ -12645,7 +12662,7 @@
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "Li" = (
 /obj/machinery/gulag_teleporter,
@@ -12834,7 +12851,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "LF" = (
 /obj/structure/chair/office{
@@ -13119,7 +13136,7 @@
 	dir = 8;
 	piping_layer = 2
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "Mu" = (
 /obj/machinery/door/airlock/ship/external/glass{
@@ -13258,7 +13275,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/tile_marquee,
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/alt,
 /area/engine/atmos)
 "MT" = (
 /obj/machinery/door/firedoor/border_only{
@@ -13298,7 +13315,7 @@
 	target_layer = 2;
 	name = "Distribution loop gas flow meter"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "MX" = (
 /obj/effect/turf_decal/tile/ship/green,
@@ -13392,7 +13409,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer2{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "No" = (
 /obj/structure/lattice,
@@ -13785,7 +13802,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "OB" = (
 /obj/structure/table/wood,
@@ -13871,7 +13888,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "OK" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -13881,7 +13898,7 @@
 	dir = 6
 	},
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "OO" = (
 /obj/effect/turf_decal/stripes/line,
@@ -13979,7 +13996,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "Pc" = (
 /obj/effect/spawner/room/fivexfour,
@@ -14473,7 +14490,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "Qy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -14515,7 +14532,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "QC" = (
 /obj/structure/cable{
@@ -14597,7 +14614,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan,
 /obj/structure/extinguisher_cabinet/west,
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "QN" = (
 /obj/machinery/light/small{
@@ -14613,7 +14630,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer2{
 	dir = 6
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "QP" = (
 /obj/structure/cable{
@@ -14783,7 +14800,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "Rl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -14833,7 +14850,7 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "Ru" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -14846,7 +14863,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "Rv" = (
 /obj/effect/turf_decal/stripes/line{
@@ -14999,6 +15016,19 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons/gauss/battery/deck2/starboard)
+"RU" = (
+/obj/effect/turf_decal/ship/delivery/yellow,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/landmark/zebra_interlock_point,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "RV" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -15074,7 +15104,7 @@
 	name = "Waste Tank Outlet"
 	},
 /obj/machinery/portable_atmospherics/scrubber/huge/movable,
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "Sf" = (
 /obj/structure/closet/radiation,
@@ -15551,14 +15581,14 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 9
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -15780,7 +15810,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "Uc" = (
 /turf/open/floor/monotile/steel,
@@ -16076,7 +16106,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "UR" = (
 /obj/machinery/status_display/ai/north,
@@ -16350,7 +16380,7 @@
 	dir = 8;
 	piping_layer = 2
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "VH" = (
 /obj/structure/disposalpipe/segment,
@@ -16568,7 +16598,7 @@
 /area/security/brig)
 "Wu" = (
 /obj/machinery/airalarm/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "Ww" = (
 /obj/machinery/button/door{
@@ -16724,23 +16754,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "WY" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/durasteel/alt,
-/area/hallway/nsv/deck2/primary)
+/obj/machinery/computer/atmos_control/tank/incinerator,
+/turf/open/floor/monotile/steel,
+/area/engine/atmos)
 "WZ" = (
 /obj/effect/turf_decal/tile/ship/yellow{
 	dir = 4
@@ -17093,7 +17112,7 @@
 	dir = 10
 	},
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "Yn" = (
 /obj/structure/rack,
@@ -17141,7 +17160,7 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "Yt" = (
 /obj/structure/table,
@@ -17528,7 +17547,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "ZC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -46614,11 +46633,11 @@ hp
 WH
 ko
 vd
-lu
-zY
-zY
-zY
-zY
+zI
+pt
+pt
+pt
+pt
 Tw
 zY
 zY
@@ -46871,7 +46890,7 @@ ew
 rf
 rQ
 nO
-Tg
+RU
 kL
 tF
 am
@@ -47128,8 +47147,8 @@ qI
 eJ
 kq
 pc
-pt
-zI
+eD
+RN
 RN
 RN
 RN
@@ -47650,8 +47669,8 @@ RN
 ac
 ac
 wC
-mj
-mj
+qg
+WY
 RN
 oX
 un
@@ -48167,8 +48186,8 @@ mj
 mj
 mj
 RN
-WY
-lx
+Jz
+un
 Dv
 yf
 Nr

--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -15,12 +15,14 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "ac" = (
-/obj/machinery/atmospherics/pipe/simple/cyan{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 8
 	},
 /obj/machinery/door/poddoor/incinerator_atmos_main,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
 /turf/open/floor/plating,
-/area/engine/atmos)
+/area/engine/atmospherics_engine)
 "ad" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -31,6 +33,9 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump/layer4{
 	name = "O2 to mix"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
@@ -589,6 +594,9 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
+"bH" = (
+/turf/closed/wall/r_wall,
+/area/engine/atmospherics_engine)
 "bI" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -654,6 +662,10 @@
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=hmain2";
 	location = "hmain1"
+	},
+/obj/structure/cable{
+	icon_state = "2-8";
+	tag = ""
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -752,6 +764,9 @@
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/structure/fireaxecabinet{
 	pixel_y = 32
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
@@ -1088,7 +1103,6 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/nsv/deck2/primary)
 "dq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -1096,7 +1110,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "dr" = (
@@ -1256,9 +1271,6 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "dS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -1289,6 +1301,10 @@
 "dW" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	name = "Output to Space"
+	},
+/obj/machinery/firealarm/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
@@ -1464,6 +1480,9 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /obj/effect/landmark/start/atmospheric_technician,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "ew" = (
@@ -2091,7 +2110,7 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "gd" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/machinery/atmospherics/components/binary/pump{
 	dir = 1
 	},
 /turf/open/floor/monotile/steel,
@@ -2165,7 +2184,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/engine/atmos)
+/area/engine/atmospherics_engine)
 "gn" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
 	dir = 8
@@ -2173,6 +2192,9 @@
 /obj/machinery/camera/autoname{
 	c_tag = "Atmos - Airlock #2";
 	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
@@ -2304,6 +2326,13 @@
 /obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
+"gG" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/steel,
+/area/engine/atmos)
 "gH" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -2615,7 +2644,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/engine/atmos)
+/area/engine/atmospherics_engine)
 "hw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2673,6 +2702,15 @@
 /obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"hB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/steel,
+/area/engine/atmos)
 "hC" = (
 /obj/effect/turf_decal/tile/ship/half/green,
 /obj/effect/turf_decal/tile/ship/green{
@@ -2704,8 +2742,15 @@
 	dir = 1;
 	id = "iowaturb"
 	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
 /turf/open/floor/monotile/steel,
-/area/engine/atmos)
+/area/engine/atmospherics_engine)
 "hI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2788,6 +2833,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
+"hZ" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/monotile/steel,
+/area/engine/atmos)
 "ia" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2986,12 +3041,13 @@
 /area/nsv/weapons)
 "iF" = (
 /obj/machinery/light_switch/south,
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/tile/yellow/tile_marquee{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue/tile_marquee,
-/turf/open/floor/durasteel/alt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "iH" = (
 /obj/structure/cable{
@@ -3168,7 +3224,8 @@
 /turf/open/floor/engine,
 /area/quartermaster/storage)
 "je" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/violet/visible,
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "jf" = (
@@ -3728,20 +3785,12 @@
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/miningoffice)
 "ky" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/holopad,
 /turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck2/primary)
+/area/engine/atmos)
 "kz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -3860,18 +3909,9 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "kO" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/durasteel/alt,
-/area/hallway/nsv/deck2/primary)
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmospherics_engine)
 "kP" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/structure/cable{
@@ -3998,8 +4038,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/chair,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/monotile/steel,
-/area/engine/atmos)
+/area/engine/atmospherics_engine)
 "li" = (
 /obj/machinery/armour_plating_nanorepair_pump/forward_starboard{
 	apnw_id = "atlas_comedy"
@@ -4017,18 +4059,17 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "lm" = (
-/obj/machinery/igniter/incinerator_atmos,
 /obj/effect/decal/cleanable/ash,
 /obj/machinery/sparker{
 	id = "atmos_incinerator_igniter";
 	pixel_x = -19
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4;
-	filter_types = list("co2","bz","water_vapor")
+/obj/machinery/air_sensor/atmos/incinerator_tank,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
+	dir = 4
 	},
 /turf/open/floor/engine/airless,
-/area/engine/atmos)
+/area/engine/atmospherics_engine)
 "ln" = (
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -4288,29 +4329,26 @@
 /turf/open/floor/monotile/steel,
 /area/science)
 "lW" = (
-/obj/machinery/atmospherics/pipe/simple/cyan{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/violet/hidden{
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos)
+/area/engine/atmospherics_engine)
 "lX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/auto_name/east,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/extinguisher_cabinet/east,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "lY" = (
-/obj/machinery/atmospherics/pipe/simple/cyan{
+/obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 10
 	},
 /turf/closed/wall/r_wall,
@@ -4391,11 +4429,14 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "mr" = (
-/obj/structure/extinguisher_cabinet/east,
-/obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "ms" = (
@@ -4504,7 +4545,7 @@
 	id = "atmos_incinerator_auxvent"
 	},
 /turf/open/floor/engine/airless,
-/area/engine/atmos)
+/area/engine/atmospherics_engine)
 "mK" = (
 /obj/structure/closet/cardboard,
 /obj/item/relic,
@@ -4559,6 +4600,9 @@
 	dir = 4
 	},
 /obj/machinery/computer/atmos_control/tank/oxygen_tank,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "mX" = (
@@ -4720,6 +4764,13 @@
 /obj/machinery/status_display/ai/north,
 /turf/open/floor/wood,
 /area/chapel/main)
+"nt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "nu" = (
 /obj/structure/ladder,
 /turf/open/floor/plating,
@@ -4840,12 +4891,12 @@
 /area/engine/atmos)
 "nH" = (
 /obj/effect/decal/cleanable/ash/large,
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4;
+	id_tag = "incinerator_out"
 	},
-/obj/machinery/air_sensor/atmos/incinerator_tank,
 /turf/open/floor/engine/airless,
-/area/engine/atmos)
+/area/engine/atmospherics_engine)
 "nI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4910,6 +4961,8 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "nO" = (
@@ -5144,6 +5197,12 @@
 /obj/item/clothing/ears/earmuffs,
 /turf/open/floor/engine,
 /area/quartermaster/storage)
+"oy" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/atmospherics_engine)
 "oz" = (
 /turf/open/floor/monotile/steel,
 /area/engine/engine_room)
@@ -5306,8 +5365,9 @@
 /area/hallway/nsv/deck2/primary)
 "oW" = (
 /obj/machinery/power/compressor,
+/obj/structure/cable/yellow,
 /turf/open/floor/engine/airless,
-/area/engine/atmos)
+/area/engine/atmospherics_engine)
 "oX" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
@@ -5521,10 +5581,6 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "pw" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=hmains4";
 	location = "hmains2"
@@ -5534,6 +5590,12 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -5623,7 +5685,7 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "pH" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "pJ" = (
@@ -5823,8 +5885,8 @@
 /turf/closed/wall/r_wall,
 /area/science/nanite)
 "qg" = (
-/turf/open/floor/durasteel/alt,
-/area/engine/atmos)
+/turf/open/floor/monotile/steel,
+/area/engine/atmospherics_engine)
 "qi" = (
 /obj/machinery/door/airlock/ship/maintenance,
 /obj/machinery/door/firedoor/border_only,
@@ -6162,7 +6224,7 @@
 /area/maintenance/nsv/deck2/port/fore)
 "ro" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
@@ -6198,8 +6260,14 @@
 /obj/machinery/power/turbine{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
 /turf/open/floor/engine/airless,
-/area/engine/atmos)
+/area/engine/atmospherics_engine)
 "rv" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -6416,9 +6484,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -6434,6 +6499,15 @@
 	},
 /turf/open/floor/carpet/ship,
 /area/nsv/weapons)
+"sc" = (
+/obj/machinery/atmospherics/pipe/simple/cyan{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/incinerator_atmos_main,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/turf/open/floor/plating,
+/area/engine/atmospherics_engine)
 "se" = (
 /obj/effect/turf_decal/tile/ship/half/neutral{
 	dir = 8
@@ -6740,6 +6814,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "th" = (
@@ -6912,6 +6989,9 @@
 /obj/machinery/computer/atmos_control/tank/carbon_tank,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
@@ -7203,12 +7283,19 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "uq" = (
-/obj/effect/turf_decal/tile/ship/green,
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east,
-/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
 "ur" = (
@@ -7338,6 +7425,13 @@
 	},
 /turf/open/floor/wood,
 /area/chapel/main)
+"uB" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/atmospherics_engine)
 "uC" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -7669,6 +7763,14 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/nsv/deck2/starboard)
+"vy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck2/primary)
 "vA" = (
 /obj/machinery/shield_generator,
 /obj/structure/cable/yellow{
@@ -7957,7 +8059,7 @@
 	pixel_x = 6
 	},
 /turf/closed/wall/r_wall,
-/area/engine/atmos)
+/area/engine/atmospherics_engine)
 "wD" = (
 /obj/machinery/door/poddoor{
 	id = "disposalgun";
@@ -8138,6 +8240,8 @@
 /area/maintenance/nsv/deck2/port/fore)
 "xd" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "xe" = (
@@ -8324,6 +8428,12 @@
 	name = "Reactor Mix Control";
 	output_tag = "sdmix_out";
 	sensors = list("sdmix_sensor"="Reactor                Mix                Tank")
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
@@ -8605,10 +8715,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=hsouth1";
 	location = "hmains1"
@@ -8620,6 +8726,8 @@
 	id = "deck2_munitions";
 	next_id = "deck2_eva"
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "yF" = (
@@ -8721,8 +8829,9 @@
 /turf/closed/wall/steel,
 /area/quartermaster/storage)
 "yU" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	dir = 1
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
@@ -8782,6 +8891,12 @@
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/miningoffice)
+"zd" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/monotile/steel,
+/area/engine/atmos)
 "ze" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -9423,6 +9538,13 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/science)
+"Bf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/monotile/steel,
+/area/engine/atmos)
 "Bh" = (
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 8
@@ -9448,6 +9570,12 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/nsv/deck2/port/fore)
+"Bo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/monotile/steel,
+/area/engine/atmos)
 "Bp" = (
 /obj/machinery/light{
 	dir = 4
@@ -9518,6 +9646,9 @@
 	dir = 4
 	},
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "BD" = (
@@ -9661,9 +9792,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "BX" = (
@@ -9822,13 +9951,8 @@
 	dir = 4;
 	nightshift_brightness = 1
 	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/tile/black,
-/obj/effect/turf_decal/tile/yellow/tile_marquee{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/tile_marquee,
-/turf/open/floor/durasteel/alt,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "Cw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -10423,6 +10547,12 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
+"ED" = (
+/obj/machinery/atmospherics/components/trinary/mixer{
+	dir = 1
+	},
+/turf/open/floor/monotile/steel,
+/area/engine/atmos)
 "EE" = (
 /turf/template_noop,
 /area/maintenance/nsv/deck2/port/fore)
@@ -10600,6 +10730,9 @@
 	name = "Nitrogen to Air Mix";
 	target_pressure = 2000
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "Fh" = (
@@ -10756,7 +10889,14 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
 	},
-/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/sign/warning/fire{
+	pixel_y = 32
+	},
 /turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "FD" = (
@@ -10924,6 +11064,20 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"Ga" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/steel,
+/area/engine/atmos)
 "Gd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -10988,9 +11142,6 @@
 /area/science)
 "Gj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
 	sortType = 6
@@ -10998,6 +11149,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "Gk" = (
@@ -11606,6 +11758,16 @@
 /obj/machinery/deck_turret/powder_gate,
 /turf/open/floor/plating,
 /area/nsv/weapons)
+"HT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/floor/monotile/steel,
+/area/engine/atmos)
 "HW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -11664,6 +11826,13 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/security/brig)
+"Ik" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/monotile/steel,
+/area/engine/atmos)
 "Il" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -11675,12 +11844,12 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "Im" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
 /obj/machinery/meter/atmos{
 	target_layer = 4;
 	name = "Scrubber loop gas flow meter"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
+	dir = 9
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
@@ -12018,6 +12187,14 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
+"Js" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "Jt" = (
 /obj/effect/turf_decal/ship/techfloor{
 	dir = 8
@@ -12664,6 +12841,15 @@
 	},
 /turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
+"Lf" = (
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/durasteel/alt,
+/area/hallway/nsv/deck2/primary)
 "Li" = (
 /obj/machinery/gulag_teleporter,
 /obj/effect/turf_decal/stripes/line,
@@ -12720,6 +12906,19 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/secondary/exit/departure_lounge)
+"Ln" = (
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/warning/fire{
+	pixel_y = -32
+	},
+/turf/open/floor/durasteel/alt,
+/area/hallway/nsv/deck2/primary)
 "Lo" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 8
@@ -13271,10 +13470,7 @@
 /area/maintenance/department/science)
 "MR" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/tile/yellow/tile_marquee{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/tile_marquee,
+/obj/effect/turf_decal/box,
 /turf/open/floor/durasteel/alt,
 /area/engine/atmos)
 "MT" = (
@@ -13310,11 +13506,11 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "MW" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/meter/atmos/distro_loop{
 	target_layer = 2;
 	name = "Distribution loop gas flow meter"
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer2,
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "MX" = (
@@ -13894,10 +14090,13 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/item/radio/intercom/directional/north,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
 	dir = 6
 	},
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "OO" = (
@@ -14532,6 +14731,10 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "QC" = (
@@ -14612,8 +14815,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan,
 /obj/structure/extinguisher_cabinet/west,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/violet/visible,
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "QN" = (
@@ -14800,6 +15006,8 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
 	},
+/obj/machinery/door/firedoor/border_only/directional/east,
+/obj/machinery/door/firedoor/border_only/directional/west,
 /turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "Rl" = (
@@ -14850,6 +15058,9 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "Ru" = (
@@ -14857,11 +15068,14 @@
 	dir = 10
 	},
 /obj/machinery/light_switch/east,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer4{
+	dir = 4
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
@@ -15212,6 +15426,10 @@
 	},
 /turf/open/floor/durasteel/alt,
 /area/hallway/secondary/exit/departure_lounge)
+"Sv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/monotile/steel,
+/area/engine/atmos)
 "Sy" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small{
@@ -15807,8 +16025,8 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/engine/engine_room)
 "Ub" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
@@ -16200,6 +16418,15 @@
 /obj/structure/overmap/small_craft/transport/sabre/mining,
 /turf/open/floor/plasteel/techmaint,
 /area/nsv/hanger/mining)
+"Vh" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/monotile/steel,
+/area/engine/atmos)
 "Vi" = (
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
@@ -16598,6 +16825,13 @@
 /area/security/brig)
 "Wu" = (
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "Ww" = (
@@ -16753,13 +16987,18 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4,
 /turf/open/floor/monotile/steel,
 /area/engine/atmos)
 "WY" = (
-/obj/machinery/computer/atmos_control/tank/incinerator,
+/obj/machinery/computer/atmos_control/tank/incinerator{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/monotile/steel,
-/area/engine/atmos)
+/area/engine/atmospherics_engine)
 "WZ" = (
 /obj/effect/turf_decal/tile/ship/yellow{
 	dir = 4
@@ -17159,6 +17398,9 @@
 "Ys" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
@@ -17655,7 +17897,7 @@
 /turf/open/floor/carpet/royalblack,
 /area/chapel/main)
 "ZR" = (
-/obj/machinery/atmospherics/pipe/simple/cyan,
+/obj/machinery/atmospherics/pipe/simple/violet/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "ZS" = (
@@ -46897,8 +47139,8 @@ am
 ps
 tm
 kL
+Lf
 kL
-uq
 mv
 Tg
 bD
@@ -47147,17 +47389,17 @@ qI
 eJ
 kq
 pc
-eD
-RN
-RN
-RN
-RN
-RN
-RN
-RN
-RN
-RN
-RN
+oy
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
+bH
 Qv
 kq
 Ll
@@ -47411,10 +47653,10 @@ ru
 oW
 nH
 lm
-YT
+kO
 lh
 hH
-RN
+bH
 zf
 un
 bB
@@ -47660,18 +47902,18 @@ zY
 zY
 dP
 kt
-BH
-eD
+Ln
+oy
 lW
-RN
-YT
-RN
+bH
+uB
+bH
 ac
-ac
+sc
 wC
 qg
 WY
-RN
+bH
 oX
 un
 NC
@@ -47917,7 +48159,7 @@ Tm
 Vc
 ju
 SX
-ny
+Fu
 eD
 lY
 ZR
@@ -47926,7 +48168,7 @@ QL
 je
 yU
 gd
-mj
+ED
 Wu
 RN
 FI
@@ -48173,21 +48415,21 @@ Jf
 Mw
 qI
 Kk
-ky
-kO
+un
+Ef
 lw
 mf
 RN
-mj
-mj
+hZ
+Vh
 ro
-QB
-mj
-mj
-mj
-RN
-Jz
-un
+Sv
+Bf
+HT
+Ga
+Js
+uq
+vy
 Dv
 yf
 Nr
@@ -48436,11 +48678,11 @@ RN
 cf
 YT
 xI
-mj
+zd
 QB
-mj
-mj
-MR
+zd
+hB
+gG
 iF
 iY
 Jz
@@ -48692,7 +48934,7 @@ TU
 RN
 bx
 pH
-BU
+Ik
 BU
 JU
 mj
@@ -49978,7 +50220,7 @@ RN
 RN
 RN
 ev
-OJ
+ky
 VG
 Mt
 xq
@@ -51008,7 +51250,7 @@ RN
 cs
 ZB
 Qx
-HW
+Bo
 LE
 RN
 RN
@@ -51265,7 +51507,7 @@ pH
 ad
 mY
 nM
-HW
+Bo
 Ym
 pH
 KF
@@ -52036,7 +52278,7 @@ RN
 OK
 Im
 mj
-HW
+Bo
 nz
 RN
 RN
@@ -52286,7 +52528,7 @@ gI
 WN
 XW
 bW
-Vc
+nt
 RK
 Xu
 La

--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -15198,6 +15198,14 @@
 /obj/effect/turf_decal/tile/ship/blue{
 	dir = 1
 	},
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser{
+	pixel_y = 8
+	},
+/obj/item/pipe_dispenser{
+	pixel_x = 6
+	},
+/obj/structure/rack,
 /turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "Rl" = (

--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -15,18 +15,12 @@
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "ac" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+/obj/machinery/atmospherics/pipe/simple/cyan{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/ship/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/blue,
+/obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/engine/atmos)
 "ad" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -531,12 +525,9 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/science/explab)
 "bx" = (
-/obj/effect/turf_decal/tile/ship/blue,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos,
+/turf/open/floor/engine/vacuum,
+/area/engine/atmos)
 "bz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -1296,16 +1287,11 @@
 /turf/open/floor/monotile/steel,
 /area/science/explab)
 "dW" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/components/binary/valve{
+	name = "Output to Space"
 	},
-/obj/structure/cable{
-	icon_state = "4-16"
-	},
-/obj/effect/turf_decal/ship/shutoff,
-/obj/effect/turf_decal/box,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/engine/atmos)
 "dX" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
@@ -1531,16 +1517,11 @@
 /turf/open/floor/carpet/orange,
 /area/engine/engine_room)
 "eD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/ship/yellow{
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/engine/atmos)
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "eF" = (
 /obj/machinery/atmospherics/components/trinary/mixer/layer4{
 	dir = 8
@@ -2068,10 +2049,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/dark,
 /area/security/brig)
-"fX" = (
-/obj/machinery/holopad,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "fZ" = (
 /turf/open/floor/monotile/dark,
 /area/science/explab)
@@ -2114,15 +2091,11 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "gd" = (
-/obj/effect/turf_decal/tile/ship/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/blue{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/engine/atmos)
 "ge" = (
 /obj/machinery/computer/security/telescreen/atc{
 	network = list("hangar_atlas");
@@ -2187,22 +2160,19 @@
 	},
 /area/maintenance/nsv/deck2/starboard)
 "gm" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table,
-/obj/item/weldingtool/mini,
-/obj/effect/turf_decal/tile/ship/yellow{
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/ship/blue{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/turf/open/space/basic,
+/area/engine/atmos)
 "gn" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
 	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	c_tag = "Atmos - Airlock #2";
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -2640,13 +2610,12 @@
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
 "hv" = (
-/obj/structure/grille,
-/obj/effect/turf_decal/tile/ship/yellow{
-	dir = 8
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/ship/blue,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/engine/atmos)
 "hw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2731,17 +2700,10 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/nsv/deck2/port)
 "hH" = (
-/obj/machinery/computer/atmos_control/tank/air_tank{
-	dir = 4;
-	input_tag = "sdmix_in";
-	name = "Reactor Mix Control";
-	output_tag = "sdmix_out";
-	sensors = list("sdmix_sensor"="Reactor                Mix                Tank")
+/obj/machinery/computer/turbine_computer{
+	dir = 1;
+	id = "iowaturb"
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "hI" = (
@@ -3024,9 +2986,13 @@
 /area/nsv/weapons)
 "iF" = (
 /obj/machinery/light_switch/south,
-/obj/structure/ladder,
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/tile/yellow/tile_marquee{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/tile_marquee,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/engine/atmos)
 "iH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3160,7 +3126,7 @@
 "iY" = (
 /obj/structure/sign/ship/nosmoking,
 /turf/closed/wall/r_wall,
-/area/maintenance/department/engine/atmos)
+/area/engine/atmos)
 "ja" = (
 /obj/structure/fighter_launcher/launch_only{
 	dir = 4;
@@ -3202,10 +3168,7 @@
 /turf/open/floor/engine,
 /area/quartermaster/storage)
 "je" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/cyan,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "jf" = (
@@ -4032,11 +3995,11 @@
 /turf/open/floor/plasteel/techmaint,
 /area/quartermaster/miningoffice)
 "lh" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/machinery/light{
+	dir = 8
 	},
-/area/maintenance/department/engine/atmos)
+/turf/open/floor/plating,
+/area/engine/atmos)
 "li" = (
 /obj/machinery/armour_plating_nanorepair_pump/forward_starboard{
 	apnw_id = "atlas_comedy"
@@ -4054,10 +4017,14 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "lm" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/machinery/igniter/incinerator_atmos,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4;
+	filter_types = list("co2","bz","water_vapor")
 	},
-/area/maintenance/department/engine/atmos)
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "ln" = (
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/firedoor/border_only/directional/west,
@@ -4119,20 +4086,11 @@
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/engine/shield_generator)
 "lw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 10
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Engineering wing maintenance";
-	req_one_access_txt = "10;24"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "lx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4326,17 +4284,11 @@
 /turf/open/floor/monotile/steel,
 /area/science)
 "lW" = (
-/obj/structure/cable{
-	icon_state = "4-16"
+/obj/machinery/atmospherics/pipe/simple/cyan{
+	dir = 4
 	},
-/obj/machinery/portable_atmospherics/pump,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/ship/shutoff,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "lX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -4354,11 +4306,11 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "lY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/cyan{
+	dir = 10
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "lZ" = (
 /obj/effect/turf_decal/tile/ship/half/red{
 	dir = 1
@@ -4387,11 +4339,12 @@
 /turf/open/floor/plasteel/ridged/steel,
 /area/engine/armour_pump)
 "mf" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos{
+	id_tag = "sdmix_out";
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/turf/open/floor/engine/vacuum,
+/area/engine/atmos)
 "mg" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/item/book/granter/martial/jujitsu,
@@ -4543,9 +4496,11 @@
 /turf/open/floor/monotile/dark/airless,
 /area/nsv/hanger/notkmcstupidhanger)
 "mJ" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/obj/machinery/door/poddoor/incinerator_atmos_main{
+	id = "atmos_incinerator_auxvent"
+	},
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "mK" = (
 /obj/structure/closet/cardboard,
 /obj/item/relic,
@@ -4880,11 +4835,14 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "nH" = (
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
+/obj/effect/decal/cleanable/ash/large,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
+	dir = 4;
+	id = "turbine_in"
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/obj/machinery/air_sensor/atmos/incinerator_tank,
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "nI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5232,12 +5190,6 @@
 "oF" = (
 /turf/closed/wall/steel,
 /area/engine/engine_room)
-"oG" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
 "oH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -5350,12 +5302,9 @@
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
 "oW" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/obj/machinery/power/compressor,
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "oX" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
@@ -5560,15 +5509,11 @@
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
 "pt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/ship/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/blue,
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "pw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -6207,11 +6152,10 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "ro" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos{
-	dir = 8;
-	id_tag = "sdmix_out"
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "rq" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6242,16 +6186,11 @@
 /turf/open/floor/durasteel/eris_techfloor_alt,
 /area/engine/shield_generator)
 "ru" = (
-/obj/structure/grille/broken,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/power/turbine{
+	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/closet/crate/engineering,
-/obj/effect/spawner/lootdrop/maintenance/six,
-/obj/effect/spawner/lootdrop/gloves,
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/turf/open/floor/engine/airless,
+/area/engine/atmos)
 "rv" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -7999,17 +7938,20 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "wC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/button/door/incinerator_vent_atmos_main{
+	pixel_x = -8;
+	pixel_y = -4
 	},
-/obj/effect/turf_decal/tile/ship/yellow{
-	dir = 4
+/obj/machinery/button/door/incinerator_vent_atmos_aux{
+	pixel_y = 8;
+	pixel_x = -8
 	},
-/obj/effect/turf_decal/tile/ship/blue,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/machinery/button/ignition/incinerator/atmos{
+	pixel_y = 2;
+	pixel_x = 6
 	},
-/area/maintenance/department/engine/atmos)
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "wD" = (
 /obj/machinery/door/poddoor{
 	id = "disposalgun";
@@ -8189,12 +8131,7 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port/fore)
 "xd" = (
-/obj/structure/extinguisher_cabinet/west,
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "xe" = (
@@ -8376,19 +8313,14 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "xI" = (
-/obj/structure/cable{
-	icon_state = "2-8";
-	tag = ""
-	},
-/obj/effect/turf_decal/tile/ship/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/blue,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/computer/atmos_control/tank/air_tank{
+	input_tag = "sdmix_in";
+	name = "Reactor Mix Control";
+	output_tag = "sdmix_out";
+	sensors = list("sdmix_sensor"="Reactor                Mix                Tank")
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/engine/atmos)
 "xK" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -8783,20 +8715,11 @@
 /turf/closed/wall/steel,
 /area/quartermaster/storage)
 "yU" = (
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Engineering wing maintenance";
-	req_one_access_txt = "10;24"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
 	},
-/obj/effect/landmark/zebra_interlock_point,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/engine/atmos)
 "yV" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -9067,8 +8990,11 @@
 /turf/open/floor/monotile/steel,
 /area/science)
 "zI" = (
+/obj/machinery/atmospherics/pipe/simple/purple/hidden{
+	dir = 9
+	},
 /turf/closed/wall/r_wall,
-/area/maintenance/department/engine/atmos)
+/area/engine/atmos)
 "zJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -9254,12 +9180,6 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
-"Am" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/engine/atmos)
 "Ao" = (
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 4
@@ -9601,6 +9521,7 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/south,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "BH" = (
@@ -9705,9 +9626,8 @@
 /turf/open/floor/circuit/orange,
 /area/science/explab)
 "BU" = (
-/turf/closed/wall/r_wall{
-	layer = 2.91
-	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "BV" = (
 /obj/effect/turf_decal/ship/techfloor,
@@ -9879,10 +9799,18 @@
 /turf/open/floor/plating,
 /area/science/explab)
 "Cv" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
+/obj/machinery/light{
+	brightness = 3;
+	bulb_vacuum_brightness = 2;
+	dir = 4;
+	nightshift_brightness = 1
 	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/tile/black,
+/obj/effect/turf_decal/tile/yellow/tile_marquee{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/tile_marquee,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "Cw" = (
@@ -11580,23 +11508,6 @@
 "HI" = (
 /turf/closed/wall/r_wall,
 /area/engine/armour_pump)
-"HJ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/purple/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/zebra_interlock_point,
-/obj/machinery/door/airlock/ship/maintenance{
-	name = "Engineering wing maintenance";
-	req_one_access_txt = "10;24"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
 "HK" = (
 /obj/machinery/light{
 	dir = 1
@@ -12529,10 +12440,6 @@
 /obj/machinery/status_display/evac/north,
 /turf/open/floor/durasteel/alt,
 /area/hallway/secondary/exit/departure_lounge)
-"KB" = (
-/obj/structure/ladder,
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
 "KD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13346,18 +13253,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "MR" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/effect/turf_decal/tile/ship/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/blue{
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/tile/yellow/tile_marquee{
 	dir = 1
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/maintenance/department/engine/atmos)
+/obj/effect/turf_decal/tile/blue/tile_marquee,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "MT" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -14610,11 +14512,10 @@
 /turf/open/floor/monotile/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "QB" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos{
-	dir = 4;
-	id = "sdmix_in"
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
-/turf/open/floor/engine/vacuum,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "QC" = (
 /obj/structure/cable{
@@ -14691,14 +14592,13 @@
 /turf/open/floor/monotile/dark,
 /area/engine/engine_room)
 "QL" = (
-/obj/machinery/light/small,
-/obj/structure/closet/toolcloset,
-/obj/effect/turf_decal/tile/ship/yellow{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/ship/blue,
+/obj/machinery/atmospherics/pipe/simple/cyan,
+/obj/structure/extinguisher_cabinet/west,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/engine/atmos)
 "QN" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -14883,7 +14783,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 5
 	},
-/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "Rl" = (
@@ -16668,12 +16567,9 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "Wu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/area/engine/atmos)
 "Ww" = (
 /obj/machinery/button/door{
 	id = "muni_atlas";
@@ -17740,12 +17636,9 @@
 /turf/open/floor/carpet/royalblack,
 /area/chapel/main)
 "ZR" = (
-/obj/effect/turf_decal/tile/ship/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/ship/blue,
-/turf/open/floor/plating,
-/area/maintenance/department/engine/atmos)
+/obj/machinery/atmospherics/pipe/simple/cyan,
+/turf/closed/wall/r_wall,
+/area/engine/atmos)
 "ZS" = (
 /obj/machinery/door/airlock/highsecurity/ship{
 	name = "Weapons Bay";
@@ -47235,17 +47128,17 @@ qI
 eJ
 kq
 pc
+pt
 zI
-zI
-zI
-zI
-zI
-HJ
-zI
-zI
-zI
-zI
-zI
+RN
+RN
+RN
+RN
+RN
+RN
+RN
+RN
+RN
 Qv
 kq
 Ll
@@ -47492,17 +47385,17 @@ qI
 sS
 un
 Ef
-zI
-zI
+hv
+gm
 mJ
 ru
 oW
 nH
 lm
-Am
+YT
 lh
-zI
-zI
+hH
+RN
 zf
 un
 bB
@@ -47749,17 +47642,17 @@ zY
 dP
 kt
 BH
-zI
+eD
 lW
-bx
-xI
-pt
+RN
+YT
+RN
+ac
 ac
 wC
-wC
-eD
-dW
-zI
+mj
+mj
+RN
 oX
 un
 NC
@@ -48006,17 +47899,17 @@ Vc
 ju
 SX
 ny
-zI
+eD
 lY
 ZR
-RN
-RN
+dW
+QL
 je
-RN
-RN
+yU
 gd
+mj
 Wu
-zI
+RN
 FI
 zQ
 ux
@@ -48265,15 +48158,15 @@ ky
 kO
 lw
 mf
-QL
 RN
-SK
+mj
+mj
 ro
-SK
+QB
+mj
+mj
+mj
 RN
-gm
-oG
-yU
 WY
 lx
 Dv
@@ -48520,14 +48413,14 @@ jE
 rf
 un
 aM
-zI
-KB
-hv
 RN
 cf
+YT
+xI
+mj
 QB
-SK
-RN
+mj
+mj
 MR
 iF
 iY
@@ -48777,17 +48670,17 @@ wd
 QG
 lx
 TU
-zI
-zI
-zI
 RN
+bx
+pH
 BU
+BU
+JU
+mj
+mj
 Cv
+MR
 RN
-RN
-zI
-zI
-zI
 Bw
 un
 ql
@@ -49038,7 +48931,7 @@ RN
 RN
 RN
 FB
-hH
+xd
 nN
 xd
 Rk
@@ -50580,7 +50473,7 @@ RN
 gu
 YT
 BC
-fX
+mj
 iu
 rx
 UQ

--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -21,7 +21,9 @@
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/cleanable/ash/large,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmospherics_engine)
 "ad" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -37,7 +39,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "ae" = (
 /obj/structure/sign/poster/contraband/random{
@@ -317,7 +323,7 @@
 /obj/machinery/atmospherics/components/trinary/mixer/flipped/layer4{
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "aV" = (
 /turf/template_noop,
@@ -768,7 +774,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "ct" = (
 /obj/structure/lattice/catwalk/over/ship,
@@ -1110,9 +1120,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer2{
+	dir = 4
+	},
+/obj/machinery/meter/atmos/distro_loop{
+	target_layer = 2;
+	name = "Distribution loop gas flow meter"
+	},
+/turf/open/floor/plating,
 /area/engine/atmos)
 "dr" = (
 /obj/effect/turf_decal/ship/techfloor/corner{
@@ -1306,7 +1321,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "dX" = (
 /obj/structure/disposalpipe/sorting/mail{
@@ -1483,7 +1502,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "ew" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1545,7 +1568,7 @@
 /obj/machinery/atmospherics/components/trinary/mixer/layer4{
 	dir = 8
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "eH" = (
 /obj/effect/landmark/carpspawn,
@@ -1635,7 +1658,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer2{
 	dir = 10
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "eY" = (
 /turf/closed/wall/r_wall,
@@ -2113,7 +2136,13 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1
 	},
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "ge" = (
 /obj/machinery/computer/security/telescreen/atc{
@@ -2196,7 +2225,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "go" = (
 /obj/structure/cable{
@@ -2327,11 +2360,13 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "gG" = (
-/obj/effect/turf_decal/stripes/corner,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "gH" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -2709,7 +2744,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "hC" = (
 /obj/effect/turf_decal/tile/ship/half/green,
@@ -2749,7 +2791,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmospherics_engine)
 "hI" = (
 /obj/effect/turf_decal/stripes/line{
@@ -2841,7 +2883,12 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/north,
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "ia" = (
 /obj/structure/cable{
@@ -2966,11 +3013,10 @@
 	name = "Abandoned Bar"
 	})
 "iu" = (
-/obj/effect/landmark/nuclear_waste_spawner,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4{
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "iv" = (
 /obj/structure/table/reinforced,
@@ -3040,14 +3086,13 @@
 /turf/open/floor/monotile/steel,
 /area/nsv/weapons)
 "iF" = (
-/obj/machinery/light_switch/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "iH" = (
 /obj/structure/cable{
@@ -3226,7 +3271,10 @@
 "je" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/violet/visible,
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 4
+	},
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "jf" = (
 /obj/structure/disposalpipe/segment{
@@ -3789,7 +3837,7 @@
 	dir = 4
 	},
 /obj/machinery/holopad,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "kz" = (
 /obj/effect/turf_decal/stripes/line{
@@ -4040,7 +4088,8 @@
 	},
 /obj/structure/chair,
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/monotile/steel,
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmospherics_engine)
 "li" = (
 /obj/machinery/armour_plating_nanorepair_pump/forward_starboard{
@@ -4059,7 +4108,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "lm" = (
-/obj/effect/decal/cleanable/ash,
 /obj/machinery/sparker{
 	id = "atmos_incinerator_igniter";
 	pixel_x = -19
@@ -4068,7 +4116,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
 	dir = 4
 	},
-/turf/open/floor/engine/airless,
+/turf/open/floor/engine/airless/light,
 /area/engine/atmospherics_engine)
 "ln" = (
 /obj/effect/landmark/zebra_interlock_point,
@@ -4335,17 +4383,15 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmospherics_engine)
 "lX" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/extinguisher_cabinet/east,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/turf/open/floor/monotile/steel,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "lY" = (
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
@@ -4393,7 +4439,14 @@
 /turf/open/floor/monotile/steel,
 /area/security/brig)
 "mj" = (
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "mk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -4436,8 +4489,10 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/engine/atmos)
 "ms" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4544,7 +4599,7 @@
 /obj/machinery/door/poddoor/incinerator_atmos_main{
 	id = "atmos_incinerator_auxvent"
 	},
-/turf/open/floor/engine/airless,
+/turf/open/floor/engine/airless/light,
 /area/engine/atmospherics_engine)
 "mK" = (
 /obj/structure/closet/cardboard,
@@ -4603,7 +4658,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "mX" = (
 /turf/open/floor/carpet/orange,
@@ -4616,13 +4675,10 @@
 	node2_concentration = 0.21;
 	piping_layer = 2
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "mZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "nc" = (
 /obj/effect/turf_decal/stripes/line,
@@ -4825,7 +4881,13 @@
 /area/hallway/nsv/deck2/primary)
 "nz" = (
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/engine/atmos)
 "nA" = (
 /obj/structure/particle_accelerator/particle_emitter/center{
@@ -4886,16 +4948,18 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "nH" = (
-/obj/effect/decal/cleanable/ash/large,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4;
 	id_tag = "incinerator_out"
 	},
-/turf/open/floor/engine/airless,
+/obj/structure/sign/warning/radiation{
+	pixel_x = -32
+	},
+/obj/effect/landmark/nuclear_waste_spawner,
+/turf/open/floor/engine/airless/light,
 /area/engine/atmospherics_engine)
 "nI" = (
 /obj/structure/disposalpipe/segment{
@@ -4954,7 +5018,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4{
 	dir = 9
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "nN" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -4963,7 +5027,7 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "nO" = (
 /obj/structure/disposalpipe/sorting/mail{
@@ -4987,11 +5051,8 @@
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck2/primary)
 "nT" = (
-/obj/machinery/atmospherics/components/binary/pump/on/layer2{
-	name = "Air to distro";
-	target_pressure = 2000
-	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer2,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "nU" = (
 /obj/structure/cable{
@@ -5017,7 +5078,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4{
 	dir = 10
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "oe" = (
 /obj/machinery/light/runway/delay5,
@@ -5149,7 +5210,7 @@
 "or" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4,
 /obj/machinery/atmospherics/pipe/manifold/purple/visible/layer2,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "os" = (
 /obj/structure/window/reinforced{
@@ -5366,7 +5427,7 @@
 "oW" = (
 /obj/machinery/power/compressor,
 /obj/structure/cable/yellow,
-/turf/open/floor/engine/airless,
+/turf/open/floor/engine/airless/light,
 /area/engine/atmospherics_engine)
 "oX" = (
 /obj/effect/turf_decal/tile/ship/green{
@@ -5885,7 +5946,7 @@
 /turf/closed/wall/r_wall,
 /area/science/nanite)
 "qg" = (
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmospherics_engine)
 "qi" = (
 /obj/machinery/door/airlock/ship/maintenance,
@@ -6226,7 +6287,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "rq" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6266,7 +6327,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/turf/open/floor/engine/airless,
+/turf/open/floor/engine/airless/light,
 /area/engine/atmospherics_engine)
 "rv" = (
 /obj/structure/rack,
@@ -6278,11 +6339,11 @@
 	name = "Abandoned Bar"
 	})
 "rx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
-/area/engine/atmos)
+/turf/open/floor/durasteel/techfloor,
+/area/maintenance/nsv/deck2/port)
 "ry" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/clothing/suit/radiation,
@@ -6506,7 +6567,9 @@
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/delivery/red,
+/obj/effect/decal/cleanable/ash,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmospherics_engine)
 "se" = (
 /obj/effect/turf_decal/tile/ship/half/neutral{
@@ -6817,7 +6880,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "th" = (
 /obj/effect/turf_decal/tile/orange{
@@ -6993,7 +7060,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "tB" = (
 /obj/machinery/firealarm{
@@ -7494,7 +7565,7 @@
 /obj/machinery/atmospherics/pipe/manifold/purple/visible/layer2{
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "uK" = (
 /turf/open/floor/plating{
@@ -7675,7 +7746,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/ship/half/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -7684,6 +7754,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/half/yellow{
+	dir = 8
 	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
@@ -7828,7 +7901,13 @@
 /obj/machinery/computer/atmos_control/tank/mix_tank{
 	dir = 1
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "vJ" = (
 /obj/machinery/conveyor{
@@ -8048,7 +8127,8 @@
 "wC" = (
 /obj/machinery/button/door/incinerator_vent_atmos_main{
 	pixel_x = -8;
-	pixel_y = -4
+	pixel_y = -4;
+	name = "turbine entrance control"
 	},
 /obj/machinery/button/door/incinerator_vent_atmos_aux{
 	pixel_y = 8;
@@ -8242,7 +8322,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "xe" = (
 /obj/structure/cable{
@@ -8323,7 +8403,13 @@
 	name = "Atmospherics RC";
 	pixel_y = -30
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "xr" = (
 /obj/machinery/turnstile{
@@ -8435,7 +8521,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "xK" = (
 /obj/structure/chair/office{
@@ -8726,8 +8816,10 @@
 	id = "deck2_munitions";
 	next_id = "deck2_eva"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "yF" = (
@@ -8833,7 +8925,10 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 4
+	},
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "yV" = (
 /obj/machinery/light/small{
@@ -8895,7 +8990,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "ze" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -9543,7 +9638,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "Bh" = (
 /obj/effect/turf_decal/ship/techfloor{
@@ -9571,10 +9672,13 @@
 	},
 /area/maintenance/nsv/deck2/port/fore)
 "Bo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "Bp" = (
 /obj/machinery/light{
@@ -9649,7 +9753,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "BD" = (
 /obj/machinery/biogenerator,
@@ -9670,7 +9778,13 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/south,
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "BH" = (
 /obj/effect/turf_decal/tile/ship/green,
@@ -9775,7 +9889,7 @@
 /area/science/explab)
 "BU" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "BV" = (
 /obj/effect/turf_decal/ship/techfloor,
@@ -9951,8 +10065,9 @@
 	dir = 4;
 	nightshift_brightness = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/monotile/steel,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/item/wrench,
+/turf/open/floor/durasteel/techfloor,
 /area/engine/atmos)
 "Cw" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -10551,7 +10666,7 @@
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 1
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "EE" = (
 /turf/template_noop,
@@ -10733,7 +10848,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "Fh" = (
 /obj/structure/rack,
@@ -10897,7 +11016,12 @@
 /obj/structure/sign/warning/fire{
 	pixel_y = 32
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/obj/structure/closet/radiation,
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "FD" = (
 /obj/machinery/button/door{
@@ -11076,7 +11200,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "Gd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -11149,7 +11274,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck2/primary)
 "Gk" = (
@@ -11251,7 +11375,13 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
 	dir = 4
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "GC" = (
 /obj/machinery/light/small{
@@ -11766,13 +11896,15 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "HW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	name = "Air to distro";
+	target_pressure = 2000;
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "HX" = (
 /obj/structure/lattice,
@@ -11831,7 +11963,32 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/bottle/vodka{
+	pixel_y = 10;
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -2
+	},
+/obj/item/geiger_counter{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 4
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 11
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "Il" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -11844,14 +12001,10 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "Im" = (
-/obj/machinery/meter/atmos{
-	target_layer = 4;
-	name = "Scrubber loop gas flow meter"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
-	dir = 9
-	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "In" = (
 /obj/effect/turf_decal/tile/ship/red,
@@ -12188,11 +12341,11 @@
 /turf/open/floor/monotile/dark,
 /area/nsv/weapons)
 "Js" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "Jt" = (
@@ -12399,7 +12552,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4{
 	dir = 5
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "JW" = (
 /obj/effect/turf_decal/ship/techfloor{
@@ -12672,7 +12825,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "KK" = (
 /obj/effect/turf_decal/tile/purple{
@@ -12794,12 +12947,12 @@
 /turf/open/floor/carpet/orange,
 /area/engine/engine_room)
 "La" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
@@ -12839,7 +12992,13 @@
 /obj/machinery/computer/atmos_control/tank/nitrous_tank{
 	dir = 1
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "Lf" = (
 /obj/effect/turf_decal/tile/ship/green,
@@ -13050,7 +13209,13 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "LF" = (
 /obj/structure/chair/office{
@@ -13177,7 +13342,6 @@
 /area/science/explab)
 "Ma" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -13335,7 +13499,8 @@
 	dir = 8;
 	piping_layer = 2
 	},
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "Mu" = (
 /obj/machinery/door/airlock/ship/external/glass{
@@ -13471,7 +13636,8 @@
 "MR" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/box,
-/turf/open/floor/durasteel/alt,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/durasteel/techfloor,
 /area/engine/atmos)
 "MT" = (
 /obj/machinery/door/firedoor/border_only{
@@ -13506,12 +13672,10 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
 "MW" = (
-/obj/machinery/meter/atmos/distro_loop{
-	target_layer = 2;
-	name = "Distribution loop gas flow meter"
+/obj/machinery/atmospherics/pipe/simple/cyan/visible/layer2{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/visible/layer2,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "MX" = (
 /obj/effect/turf_decal/tile/ship/green,
@@ -13605,7 +13769,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer2{
 	dir = 10
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "No" = (
 /obj/structure/lattice,
@@ -13998,7 +14162,13 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "OB" = (
 /obj/structure/table/wood,
@@ -14081,23 +14251,25 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "OJ" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4{
-	dir = 4
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/monotile/steel,
-/area/engine/atmos)
+/obj/item/reagent_containers/food/drinks/bottle/vodka,
+/turf/open/floor/plating,
+/area/nsv/weapons)
 "OK" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/item/radio/intercom/directional/north,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/layer_manifold/visible{
+	dir = 4
 	},
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/engine/atmos)
 "OO" = (
 /obj/effect/turf_decal/stripes/line,
@@ -14195,7 +14367,13 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "Pc" = (
 /obj/effect/spawner/room/fivexfour,
@@ -14689,7 +14867,7 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible/layer4{
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "Qy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -14735,7 +14913,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "QC" = (
 /obj/structure/cable{
@@ -14815,12 +14994,14 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/west,
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/visible,
-/turf/open/floor/monotile/steel,
+/obj/structure/sign/warning/fire{
+	pixel_x = -32
+	},
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "QN" = (
 /obj/machinery/light/small{
@@ -14836,7 +15017,7 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible/layer2{
 	dir = 6
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "QP" = (
 /obj/structure/cable{
@@ -15008,7 +15189,16 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/east,
 /obj/machinery/door/firedoor/border_only/directional/west,
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "Rl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -15061,12 +15251,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "Ru" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 10
-	},
 /obj/machinery/light_switch/east,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15077,7 +15268,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible/layer4{
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/meter/atmos{
+	target_layer = 4;
+	name = "Scrubber loop gas flow meter"
+	},
+/turf/open/floor/plating,
 /area/engine/atmos)
 "Rv" = (
 /obj/effect/turf_decal/stripes/line{
@@ -15318,7 +15513,13 @@
 	name = "Waste Tank Outlet"
 	},
 /obj/machinery/portable_atmospherics/scrubber/huge/movable,
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "Sf" = (
 /obj/structure/closet/radiation,
@@ -15428,7 +15629,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "Sv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "Sy" = (
 /obj/effect/turf_decal/stripes/line,
@@ -16028,7 +16229,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 8
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "Uc" = (
 /turf/open/floor/monotile/steel,
@@ -16324,7 +16525,13 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "UR" = (
 /obj/machinery/status_display/ai/north,
@@ -16425,7 +16632,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "Vi" = (
 /turf/open/floor/monotile/dark,
@@ -16607,7 +16814,8 @@
 	dir = 8;
 	piping_layer = 2
 	},
-/turf/open/floor/monotile/steel,
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "VH" = (
 /obj/structure/disposalpipe/segment,
@@ -16721,7 +16929,6 @@
 /area/science)
 "Wd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/airlock/ship/engineering/glass{
 	name = "Atmospherics";
 	req_one_access_txt = "24;10"
@@ -16735,7 +16942,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "We" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -16824,7 +17031,6 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "Wu" = (
-/obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
@@ -16832,7 +17038,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/light_switch/south,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "Ww" = (
 /obj/machinery/button/door{
@@ -16981,14 +17189,12 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4,
-/turf/open/floor/monotile/steel,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "WY" = (
 /obj/machinery/computer/atmos_control/tank/incinerator{
@@ -16997,7 +17203,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/monotile/steel,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmospherics_engine)
 "WZ" = (
 /obj/effect/turf_decal/tile/ship/yellow{
@@ -17099,7 +17306,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/plating,
 /area/engine/atmos)
 "Xv" = (
 /obj/effect/turf_decal/stripes/line{
@@ -17351,7 +17558,13 @@
 	dir = 10
 	},
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "Yn" = (
 /obj/structure/rack,
@@ -17402,7 +17615,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/durasteel/riveted,
+/obj/effect/turf_decal/tile/ship/blue,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "Yt" = (
 /obj/structure/table,
@@ -17789,7 +18006,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible/layer2{
 	dir = 4
 	},
-/turf/open/floor/monotile/steel,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "ZC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -48170,7 +48387,7 @@ yU
 gd
 ED
 Wu
-RN
+iY
 FI
 zQ
 ux
@@ -48684,7 +48901,7 @@ zd
 hB
 gG
 iF
-iY
+YT
 Jz
 un
 IY
@@ -48937,7 +49154,7 @@ pH
 Ik
 BU
 JU
-mj
+mZ
 mj
 Cv
 MR
@@ -49449,7 +49666,7 @@ RN
 nZ
 jh
 gn
-mj
+mZ
 aT
 JU
 BG
@@ -49706,8 +49923,8 @@ RN
 AL
 YT
 tA
-mj
-OJ
+mZ
+iu
 Ub
 Le
 YT
@@ -50725,7 +50942,7 @@ rF
 pO
 hL
 mO
-ir
+rx
 wd
 tC
 un
@@ -50734,9 +50951,9 @@ RN
 gu
 YT
 BC
-mj
+mZ
 iu
-rx
+mZ
 UQ
 YT
 bY
@@ -50993,7 +51210,7 @@ pH
 Fg
 KJ
 eF
-HW
+mZ
 GB
 jh
 lD
@@ -51250,7 +51467,7 @@ RN
 cs
 ZB
 Qx
-Bo
+mZ
 LE
 RN
 RN
@@ -51507,7 +51724,7 @@ pH
 ad
 mY
 nM
-Bo
+mZ
 Ym
 pH
 KF
@@ -52020,7 +52237,7 @@ rh
 jh
 Rs
 mZ
-mj
+mZ
 HW
 Se
 pH
@@ -52277,7 +52494,7 @@ RN
 RN
 OK
 Im
-mj
+Im
 Bo
 nz
 RN
@@ -52788,7 +53005,7 @@ QP
 ht
 eY
 eY
-eY
+OJ
 eY
 eY
 eY

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -395,10 +395,6 @@
 /area/crew_quarters/bar)
 "bm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	sortType = "19;20"
-	},
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 8
 	},
@@ -410,6 +406,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
@@ -4597,6 +4596,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
 "oV" = (
@@ -6557,9 +6559,6 @@
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/port)
 "vv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 4
 	},
@@ -6568,6 +6567,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	sortType = 21
 	},
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
@@ -8211,12 +8214,14 @@
 /area/hallway/nsv/deck1/hallway)
 "Bi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/ship/half/green{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/monotile/steel,
 /area/hydroponics)

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -176,14 +176,6 @@
 	},
 /turf/open/floor/grass,
 /area/medical/virology)
-"aD" = (
-/obj/structure/cable{
-	icon_state = "4-32"
-	},
-/obj/effect/turf_decal/ship/shutoff,
-/obj/effect/turf_decal/box,
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck1/central)
 "aE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2074,13 +2066,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"gM" = (
-/obj/structure/lattice/catwalk/over/ship,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck1/central)
 "gN" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
@@ -3150,9 +3135,6 @@
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/captain)
 "kk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Engineering wing maintenance";
@@ -6788,18 +6770,6 @@
 /obj/machinery/ship_weapon/deck_turret/east,
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
-"wg" = (
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/durasteel/alt,
-/area/hallway/nsv/deck1/hallway)
 "wh" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -7414,7 +7384,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/ladder,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/central)
 "yv" = (
@@ -7730,24 +7699,6 @@
 	},
 /turf/open/floor/monotile/steel,
 /area/hydroponics)
-"zL" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck1/hallway)
 "zM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -8285,9 +8236,6 @@
 	},
 /area/maintenance/nsv/deck1/port)
 "Bv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/landmark/zebra_interlock_point,
 /obj/machinery/door/airlock/ship/maintenance{
 	name = "Engineering wing maintenance";
@@ -8624,17 +8572,9 @@
 "CG" = (
 /turf/open/floor/durasteel/lino,
 /area/medical/genetics)
-"CI" = (
-/obj/structure/lattice/catwalk/over/ship,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck1/central)
 "CJ" = (
 /obj/structure/lattice/catwalk/over/ship,
 /obj/machinery/light/small,
-/obj/structure/ladder,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/central)
 "CK" = (
@@ -8966,23 +8906,11 @@
 /turf/open/floor/monotile/dark,
 /area/medical/genetics)
 "DE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/monotile/steel,
-/area/hallway/nsv/deck1/hallway)
+/obj/structure/lattice/catwalk/over/ship,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/light_switch/south,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/central)
 "DF" = (
 /obj/structure/bookcase/random/reference,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -14120,12 +14048,9 @@
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "UA" = (
-/obj/structure/lattice/catwalk/over/ship,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light_switch/south,
+/obj/structure/lattice/catwalk/over/ship,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/central)
 "UC" = (
@@ -14912,28 +14837,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/nsv/deck1/port)
-"Xn" = (
-/obj/structure/cable{
-	icon_state = "4-32"
-	},
-/obj/machinery/power/apc/auto_name/west,
-/obj/effect/turf_decal/box,
-/obj/effect/turf_decal/ship/shutoff,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/nsv/deck1/central)
-"Xp" = (
-/obj/effect/turf_decal/tile/ship/green,
-/obj/effect/turf_decal/tile/ship/green{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/durasteel/alt,
-/area/hallway/nsv/deck1/hallway)
 "Xr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -45641,7 +45544,7 @@ CC
 NH
 Sc
 Pm
-aD
+dF
 uj
 uj
 Vu
@@ -45649,7 +45552,7 @@ NF
 oZ
 uj
 uj
-Xn
+dF
 Pm
 MQ
 JR
@@ -45898,7 +45801,7 @@ eN
 wu
 YC
 gq
-UA
+DE
 uj
 NB
 uY
@@ -46152,10 +46055,10 @@ Fq
 vR
 Pk
 HA
-DE
-Xp
+wu
+Sc
 Bv
-gM
+dF
 uj
 kK
 Bc
@@ -46163,10 +46066,10 @@ Fu
 Nr
 ja
 uj
-CI
+dF
 kk
-wg
-zL
+MQ
+wu
 Sc
 Pk
 Qw

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -792,6 +792,11 @@
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"cR" = (
+/obj/structure/lattice/catwalk/over/ship,
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/central)
 "cU" = (
 /obj/machinery/light{
 	dir = 1
@@ -1844,6 +1849,24 @@
 	},
 /turf/open/openspace,
 /area/maintenance/nsv/deck1/starboard)
+"fP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/monotile/steel,
+/area/hallway/nsv/deck1/hallway)
 "fQ" = (
 /obj/machinery/door/airlock/ship/maintenance/defaultaccess,
 /obj/machinery/door/firedoor/border_only{
@@ -2066,6 +2089,13 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
+"gM" = (
+/obj/structure/lattice/catwalk/over/ship,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/central)
 "gN" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
@@ -7384,6 +7414,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/central)
 "yv" = (
@@ -8243,6 +8276,9 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/south,
 /obj/machinery/door/firedoor/border_only/directional/north,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/central)
 "Bx" = (
@@ -10723,6 +10759,11 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"JD" = (
+/obj/structure/lattice/catwalk/over/ship,
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/central)
 "JF" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -14170,6 +14211,11 @@
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/circuit/red/telecomms,
 /area/tcommsat/server)
+"UT" = (
+/obj/structure/lattice/catwalk/over/ship,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/central)
 "UU" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/ship/half/green{
@@ -14442,6 +14488,14 @@
 	},
 /turf/open/floor/durasteel/techfloor_grid,
 /area/maintenance/nsv/deck1/port)
+"VU" = (
+/obj/structure/lattice/catwalk/over/ship,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc/auto_name/east,
+/turf/open/floor/plating,
+/area/maintenance/nsv/deck1/central)
 "VV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -15179,6 +15233,16 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"Yw" = (
+/obj/effect/turf_decal/tile/ship/green,
+/obj/effect/turf_decal/tile/ship/green{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/durasteel/alt,
+/area/hallway/nsv/deck1/hallway)
 "Yz" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -45544,7 +45608,7 @@ CC
 NH
 Sc
 Pm
-dF
+cR
 uj
 uj
 Vu
@@ -45552,7 +45616,7 @@ NF
 oZ
 uj
 uj
-dF
+JD
 Pm
 MQ
 JR
@@ -46055,10 +46119,10 @@ Fq
 vR
 Pk
 HA
-wu
-Sc
+fP
+Yw
 Bv
-dF
+gM
 uj
 kK
 Bc
@@ -46572,7 +46636,7 @@ IQ
 Qb
 Kp
 gq
-dF
+VU
 uj
 uj
 Ov
@@ -46580,7 +46644,7 @@ zY
 RI
 uj
 uj
-dF
+UT
 gq
 Hq
 wu

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -9720,6 +9720,7 @@
 "Gh" = (
 /obj/item/circuitboard/machine/protolathe,
 /obj/structure/rack,
+/obj/item/circuitboard/machine/circuit_imprinter,
 /turf/open/floor/durasteel/lino,
 /area/ai_monitored/nuke_storage)
 "Gi" = (
@@ -10692,6 +10693,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/item/hemostat/alien,
 /turf/open/floor/carpet/ship/beige_carpet,
 /area/crew_quarters/heads/hor)
 "Ju" = (


### PR DESCRIPTION
Błędy przeszłości naprawione

![ATMOS](https://github.com/aq33/NSV13/assets/52501307/569cd088-a344-4458-b6ba-6a0d4735bfb5)



## Changelog
:cl:
add: Dodano turbinę do atmosu
del: Usunięto kanał konserwacyjny atmosu
tweak: Zmieniono pomieszczenie atmosferyków
/:cl:

