### PR TITLE
RTG do kupna

### DIFF
--- a/aquila/code/modules/cargo/packs.dm
+++ b/aquila/code/modules/cargo/packs.dm
@@ -88,3 +88,11 @@
 	cost = 10000
 	contains = list(/obj/item/reagent_containers/glass/bottle/concentrated_bz)
 	crate_name = "Changeling testing kit crate"
+
+/datum/supply_pack/engineering/rtg
+	name = "Radioisotope Thermoelectric Generator Crate"
+	desc = "A crate containing a simple nuclear power generator, used in small outposts to reliably provide power for decades."
+	cost = 5000
+	contains = list(/obj/machinery/power/rtg)
+	crate_name = "RTG crate"
+	crate_type = /obj/structure/closet/crate/engineering/electrical

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -9,6 +9,7 @@
 	density = TRUE
 	use_power = NO_POWER_USE
 	circuit = /obj/item/circuitboard/machine/rtg
+	can_be_unanchored = TRUE//AQ EDIT
 
 	// You can buckle someone to RTG, then open its panel. Fun stuff.
 	can_buckle = TRUE
@@ -19,12 +20,25 @@
 
 	var/irradiate = TRUE // RTGs irradiate surroundings, but only when panel is open.
 
-/obj/machinery/power/rtg/Initialize(mapload)
+/obj/machinery/power/rtg/Initialize(mapload)//AQ EDIT
 	. = ..()
-	connect_to_network()
+	if(anchored)
+		connect_to_network()
 
-/obj/machinery/power/rtg/process()
+/obj/machinery/power/port_gen/should_have_node()
+	return anchored
+
+/obj/machinery/power/port_gen/connect_to_network()
+	if(!anchored)
+		return FALSE
+	. = ..()
+
+/obj/machinery/power/rtg/process()//AQ EDIT
 	..()
+	if(anchored)
+		connect_to_network()
+	else
+		disconnect_from_network()
 	add_avail(power_gen)
 	if(panel_open && irradiate)
 		radiation_pulse(src, 60)
@@ -40,6 +54,12 @@
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
 		. += "<span class='notice'>The status display reads: Power generation now at <b>[power_gen*0.001]</b>kW.</span>"
+
+/obj/machinery/power/rtg/wrench_act(mob/living/user, obj/item/I)
+	default_unfasten_wrench(user, I)
+
+	playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)
+	return TRUE
 
 /obj/machinery/power/rtg/attackby(obj/item/I, mob/user, params)
 	if(default_deconstruction_screwdriver(user, "[initial(icon_state)]-open", initial(icon_state), I))

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -25,8 +25,7 @@
 	if(anchored)
 		connect_to_network()
 
-/obj/machinery/power/port_gen/should_have_node()
-	return anchored
+
 
 /obj/machinery/power/port_gen/connect_to_network()
 	if(!anchored)


### PR DESCRIPTION
Można kupić RTG w cargo i przykręcać do sieci

## Changelog
:cl:
add: można kupić RTG w cargo

/:cl:

