### PR TITLE
[atlas] poprawki mapowe

### DIFF
--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -18,11 +18,9 @@
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/incinerator_atmos_main,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
 /obj/effect/turf_decal/delivery/red,
 /obj/effect/decal/cleanable/ash/large,
+/obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/durasteel/riveted,
 /area/engine/atmospherics_engine)
 "ad" = (
@@ -1127,7 +1125,13 @@
 	target_layer = 2;
 	name = "Distribution loop gas flow meter"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "dr" = (
 /obj/effect/turf_decal/ship/techfloor/corner{
@@ -1317,7 +1321,6 @@
 /obj/machinery/atmospherics/components/binary/valve{
 	name = "Output to Space"
 	},
-/obj/machinery/firealarm/directional/north,
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
@@ -4391,7 +4394,7 @@
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "lY" = (
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
@@ -4492,7 +4495,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "ms" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4884,10 +4887,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/ship/blue{
+	dir = 1
+	},
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "nA" = (
 /obj/structure/particle_accelerator/particle_emitter/center{
@@ -4948,7 +4954,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "nH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -6564,11 +6570,9 @@
 /obj/machinery/atmospherics/pipe/simple/cyan{
 	dir = 4
 	},
-/obj/machinery/door/poddoor/incinerator_atmos_main,
-/obj/machinery/door/firedoor/border_only/directional/west,
-/obj/machinery/door/firedoor/border_only/directional/east,
 /obj/effect/turf_decal/delivery/red,
 /obj/effect/decal/cleanable/ash,
+/obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/durasteel/riveted,
 /area/engine/atmospherics_engine)
 "se" = (
@@ -9675,10 +9679,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "Bp" = (
 /obj/machinery/light{
@@ -10067,6 +10068,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /obj/item/wrench,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/durasteel/techfloor,
 /area/engine/atmos)
 "Cw" = (
@@ -12000,12 +12002,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck2/port)
-"Im" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "In" = (
 /obj/effect/turf_decal/tile/ship/red,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -12952,9 +12948,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible/layer4,
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "Lb" = (
 /obj/machinery/suit_storage_unit/pilot,
@@ -14269,7 +14265,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/blue,
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "OO" = (
 /obj/effect/turf_decal/stripes/line,
@@ -15131,6 +15131,7 @@
 	dradis_id = "nt_cargo_torpedo_launcher"
 	},
 /obj/effect/turf_decal/tile/ship/half/brown,
+/obj/machinery/light,
 /turf/open/floor/monotile/dark,
 /area/quartermaster/storage)
 "Rf" = (
@@ -15280,7 +15281,11 @@
 	target_layer = 4;
 	name = "Scrubber loop gas flow meter"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/tile/ship/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/ship/blue,
+/turf/open/floor/durasteel/techfloor_grid,
 /area/engine/atmos)
 "Rv" = (
 /obj/effect/turf_decal/stripes/line{
@@ -16972,6 +16977,7 @@
 /obj/item/control_rod,
 /obj/item/control_rod,
 /obj/item/control_rod,
+/obj/item/shovel,
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "Wg" = (
@@ -17203,7 +17209,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/plating,
+/turf/open/floor/durasteel/riveted,
 /area/engine/atmos)
 "WY" = (
 /obj/machinery/computer/atmos_control/tank/incinerator{
@@ -52502,8 +52508,8 @@ RN
 RN
 RN
 OK
-Im
-Im
+mZ
+mZ
 Bo
 nz
 RN

--- a/_maps/map_files/Atlas/atlas.dmm
+++ b/_maps/map_files/Atlas/atlas.dmm
@@ -9474,6 +9474,9 @@
 	name = "Engine Core Access";
 	req_one_access_txt = "24;10"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/engine/engine_room)
 "Ay" = (
@@ -16817,6 +16820,9 @@
 /obj/machinery/door/airlock/ship/external/glass{
 	name = "Engine Core Access";
 	req_one_access_txt = "24;10"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engine_room)

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -1408,10 +1408,13 @@
 /turf/open/floor/monotile/dark,
 /area/medical/virology)
 "ez" = (
-/obj/machinery/chem_heater,
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
-/turf/open/floor/durasteel/alt,
+/obj/machinery/plortrefinery,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/techmaint,
 /area/science/xenobiology)
 "eA" = (
 /obj/machinery/requests_console{
@@ -6591,6 +6594,8 @@
 /obj/item/storage/bag/bio,
 /obj/structure/table/glass,
 /obj/machinery/camera/autoname,
+/obj/item/wrench,
+/obj/item/crowbar/red,
 /turf/open/floor/monotile/steel,
 /area/science/xenobiology)
 "vj" = (
@@ -10272,9 +10277,7 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "Ho" = (
-/obj/structure/table/glass,
-/obj/item/wrench,
-/obj/item/crowbar/red,
+/obj/machinery/chem_master,
 /turf/open/floor/monotile/steel,
 /area/science/xenobiology)
 "Hp" = (
@@ -11277,9 +11280,9 @@
 /area/engine/gravity_generator)
 "Kg" = (
 /obj/machinery/light,
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/status_display/evac/south,
+/obj/machinery/chem_heater,
 /turf/open/floor/durasteel/alt,
 /area/science/xenobiology)
 "Kj" = (
@@ -13387,15 +13390,15 @@
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/structure/extinguisher_cabinet/south,
 /obj/structure/extinguisher_cabinet/south{
 	pixel_x = -12
 	},
 /obj/structure/extinguisher_cabinet/south{
 	pixel_x = 12
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel/techmaint,
 /area/science/xenobiology)

--- a/_maps/map_files/Atlas/atlas2.dmm
+++ b/_maps/map_files/Atlas/atlas2.dmm
@@ -232,10 +232,10 @@
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 1
 	},
-/obj/machinery/vending/snack/random,
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
+/obj/machinery/vending/cola/random,
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck1/hallway)
 "aL" = (
@@ -265,6 +265,7 @@
 "aP" = (
 /obj/effect/turf_decal/tile/ship/half/green,
 /obj/structure/table/glass,
+/obj/machinery/cell_charger,
 /turf/open/floor/monotile/steel,
 /area/hallway/nsv/deck1/hallway)
 "aR" = (
@@ -1065,6 +1066,7 @@
 /obj/effect/turf_decal/tile/ship/bar{
 	dir = 8
 	},
+/obj/machinery/vending/clothing,
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
 "dC" = (
@@ -2065,7 +2067,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "bar"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "gM" = (
 /obj/structure/lattice/catwalk/over/ship,
@@ -2512,7 +2514,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/space/basic,
+/turf/open/floor/engine/airless,
 /area/medical/surgery)
 "ir" = (
 /obj/structure/chair/office{
@@ -2799,7 +2801,7 @@
 /obj/effect/turf_decal/tile/ship/green{
 	dir = 8
 	},
-/obj/machinery/vending/snack/random,
+/obj/machinery/vending/cola/random,
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck1/hallway)
 "iX" = (
@@ -2934,6 +2936,7 @@
 "jp" = (
 /obj/effect/turf_decal/ship/letter{
 	icon_state = "U";
+	pixel_x = 6;
 	pixel_y = -2
 	},
 /turf/open/floor/engine/airless,
@@ -3318,7 +3321,6 @@
 /obj/item/restraints/handcuffs/cable/zipties,
 /obj/item/restraints/handcuffs/cable/zipties,
 /obj/item/clothing/glasses/blindfold/white,
-/obj/machinery/status_display/evac/north,
 /obj/structure/table,
 /turf/open/floor/noslip/white,
 /area/medical/medbay)
@@ -3389,7 +3391,6 @@
 /obj/structure/closet/crate/secure/loot,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/spawner/lootdrop/teratoma,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plating,
 /area/maintenance/nsv/deck1/starboard)
@@ -3945,8 +3946,8 @@
 /obj/machinery/firealarm/directional/west{
 	pixel_y = 12
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
@@ -4070,7 +4071,7 @@
 	id = "bar"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "mT" = (
 /obj/machinery/vending/hydroseeds,
@@ -5393,7 +5394,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "bar"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/wood,
 /area/crew_quarters/bar)
 "ro" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -5801,9 +5802,7 @@
 /area/science/xenobiology)
 "sD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/mob/living/carbon/monkey/punpun{
-	name = "Szymek"
-	},
+/mob/living/carbon/monkey/punpun,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "sE" = (
@@ -5906,6 +5905,10 @@
 /obj/effect/turf_decal/tile/ship/blue{
 	dir = 4
 	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "sV" = (
@@ -5980,6 +5983,12 @@
 	},
 /turf/open/floor/monotile/dark,
 /area/crew_quarters/bar/mess_hall)
+"th" = (
+/obj/machinery/light/floor{
+	pixel_x = 4
+	},
+/turf/open/floor/engine/airless,
+/area/maintenance/department/science/xenobiology)
 "ti" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -9965,8 +9974,6 @@
 /area/medical/medbay)
 "Gp" = (
 /obj/structure/closet/secure_closet/medical1,
-/obj/item/storage/box/pillbottles,
-/obj/item/storage/box/medsprays,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -10374,7 +10381,7 @@
 /turf/open/floor/durasteel/alt,
 /area/hallway/nsv/deck1/hallway)
 "HB" = (
-/obj/machinery/vending/clothing,
+/obj/machinery/vending/coffee,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/bar/mess_hall)
 "HC" = (
@@ -11071,12 +11078,9 @@
 /obj/machinery/light_switch/west{
 	pixel_y = 12
 	},
-/obj/item/bedsheet/cmo,
 /mob/living/simple_animal/pet/cat/Runtime,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
 /obj/machinery/light,
+/obj/item/bedsheet/cmo,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
 "JB" = (
@@ -11254,7 +11258,10 @@
 	icon_state = "4-8"
 	},
 /obj/structure/table/wood,
-/obj/item/stamp/captain,
+/obj/item/stamp/captain{
+	pixel_y = 10
+	},
+/obj/item/storage/lockbox/medal,
 /obj/item/pinpointer/nuke,
 /obj/item/disk/nuclear,
 /turf/open/floor/monotile/steel,
@@ -11316,7 +11323,6 @@
 	name = "Captain requests console";
 	pixel_y = 32
 	},
-/obj/item/storage/lockbox/medal,
 /obj/item/melee/chainofcommand/tailwhip/kitty,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/captain)
@@ -11460,9 +11466,9 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/medical3,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/defibrillator/loaded,
 /obj/effect/turf_decal/box,
+/obj/item/defibrillator/loaded,
+/obj/item/clothing/glasses/hud/health,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "KF" = (
@@ -13119,9 +13125,6 @@
 	},
 /obj/machinery/door/firedoor/border_only/directional/west,
 /obj/machinery/door/firedoor/border_only/directional/east,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/landmark/zebra_interlock_point,
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -13320,10 +13323,8 @@
 	desc = "Skipper's bed! Looks comfy.";
 	name = "Dog Bed"
 	},
-/mob/living/simple_animal/pet/dog/pug{
-	name = "pugasus"
-	},
 /obj/item/bedsheet/captain,
+/mob/living/simple_animal/pet/fox/Renault,
 /turf/open/floor/monotile/steel,
 /area/crew_quarters/heads/captain)
 "Qf" = (
@@ -13867,7 +13868,8 @@
 /area/hallway/nsv/deck1/hallway)
 "Sd" = (
 /obj/effect/turf_decal/ship/letter{
-	icon_state = "I"
+	icon_state = "I";
+	pixel_x = 4
 	},
 /turf/open/floor/engine/airless,
 /area/space/nearstation)
@@ -14125,6 +14127,9 @@
 	pixel_x = 2;
 	pixel_y = -2
 	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/durasteel/lino,
 /area/awaymission/research/interior/genetics)
 "SX" = (
@@ -14156,6 +14161,7 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/openspace,
 /area/maintenance/nsv/deck1/starboard)
 "Tf" = (
@@ -14365,7 +14371,10 @@
 /area/bridge/cic)
 "TQ" = (
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/durasteel/lino,
 /area/awaymission/research/interior/genetics)
@@ -14932,13 +14941,22 @@
 	},
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 5;
-	layer = 3.2
+	layer = 3.2;
+	pixel_x = -8;
+	pixel_y = 8
 	},
 /obj/machinery/button/door{
 	id = "atlas_chemistry";
 	name = "Chemistry Shutters";
 	pixel_x = 23;
 	pixel_y = 24
+	},
+/obj/item/storage/box/medsprays{
+	pixel_x = 7
+	},
+/obj/item/storage/box/pillbottles{
+	pixel_y = -2;
+	pixel_x = -6
 	},
 /turf/open/floor/durasteel/lino,
 /area/medical/chemistry)
@@ -15821,6 +15839,11 @@
 /mob/living/carbon/monkey,
 /turf/open/floor/grass,
 /area/medical/virology)
+"YH" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/science/xenobiology)
 "YI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -16039,9 +16062,6 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/structure/sink{
-	pixel_y = 32
-	},
 /obj/machinery/button/door{
 	dir = 8;
 	id = "izolatka";
@@ -16052,6 +16072,7 @@
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile/ship/blue,
+/obj/machinery/status_display/evac/north,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay)
 "Zx" = (
@@ -16218,9 +16239,10 @@
 /turf/open/floor/monotile/light,
 /area/medical/medbay)
 "ZV" = (
-/obj/machinery/door/window/westright{
+/obj/machinery/door/window/brigdoor{
 	name = "Monkey Pen";
-	req_access_txt = "39"
+	req_access_txt = "39";
+	dir = 8
 	},
 /turf/open/floor/grass,
 /area/medical/virology)
@@ -52113,7 +52135,7 @@ eD
 cB
 cB
 sk
-WR
+mt
 Fx
 oQ
 WR
@@ -52627,7 +52649,7 @@ cH
 cH
 Zw
 kW
-WR
+cH
 TF
 Yu
 WR
@@ -52884,7 +52906,7 @@ RQ
 cH
 Wa
 Xg
-cp
+dQ
 cp
 cp
 cp
@@ -53910,7 +53932,7 @@ WJ
 iH
 dO
 dR
-na
+dQ
 dQ
 dQ
 mK
@@ -57241,7 +57263,7 @@ Tf
 Tf
 fT
 Lo
-TK
+YH
 pb
 JZ
 gr
@@ -59801,7 +59823,7 @@ mK
 mK
 Rg
 cx
-bJ
+th
 Sd
 jv
 mK
@@ -60819,7 +60841,7 @@ uf
 uf
 uf
 uf
-mK
+uf
 mK
 mK
 mK


### PR DESCRIPTION
genetyka dostaje swoje apc, poprawia kable, brakujace turfy, guziki w atmos, podloge pod ladą barową, renault, venty pod apc, wyrównuje litery w napisie na kadłubie, dodaje automaty do picia na korytarzu, dodaje plort machine do xeno, wyjmuje pare rzeczy z szafek na stoly bo sie nie mieszcza itd.